### PR TITLE
Add fast-lane implementation to speedup back implementation

### DIFF
--- a/brigand/back.hpp
+++ b/brigand/back.hpp
@@ -2,69 +2,53 @@
 #pragma once
 
 #include <brigand/list.hpp>
-#include <brigand/append.hpp>
+#include <brigand/detail/last_element.hpp>
 
 namespace brigand
 {
   // push_back
-  template<class L, class... T> struct push_back_impl;
-
-  template<template<class...> class L, class... U, class... T>
-  struct push_back_impl<L<U...>, T...>
+  namespace detail
   {
-      using type = L<U..., T...>;
-  };
+    template<class L, class... T> struct push_back_impl;
+
+    template<template<class...> class L, class... U, class... T>
+    struct push_back_impl<L<U...>, T...>
+    {
+        using type = L<U..., T...>;
+    };
+  }
 
   template<class L, class... T>
-  using push_back = typename push_back_impl<L, T...>::type;
+  using push_back = typename detail::push_back_impl<L, T...>::type;
 
   // back
-
-  // mmm no other way than recursion to get the last? I think there must...
-  template <class First, class... R>
-  struct last_element
+  namespace detail
   {
-      using type = typename last_element<R...>::type;
-  };
+    template<class L> struct back_impl;
 
-  template <class Last>
-  struct last_element<Last>
-  {
-      using type = Last;
-  };
-
-  template<class L> struct back_impl;
-
-  template<template<class...> class L, class... U>
-  struct back_impl<L<U...>>
-  {
+    template<template<class...> class L, class... U>
+    struct back_impl<L<U...>>
+    {
       using type = typename last_element<U...>::type;
-  };
+    };
+
+  }
 
   template <class L>
-  using back = typename back_impl<L>::type;
+  using back = typename detail::back_impl<L>::type;
 
   // pop back
-  template <template <class...> class L, class First, class... R>
-  struct without_last_element
+  namespace detail
   {
-      using type = append<L<First>, typename  without_last_element<L, R...>::type>;
-  };
+    template <class L> struct pop_back_impl;
 
-  template <template <class...> class L, class Last>
-  struct without_last_element<L, Last>
-  {
-      using type = empty_list;
-  };
-
-  template <class L> struct pop_back_impl;
-
-  template<template<class...> class L, class... U>
-  struct pop_back_impl<L<U...>>
-  {
-      using type = typename without_last_element<L, U...>::type;
-  };
+    template<template<class...> class L, class... U>
+    struct pop_back_impl<L<U...>>
+    {
+        using type = typename without_last_element<L, U...>::type;
+    };
+  }
 
   template <class L>
-  using pop_back = typename pop_back_impl<L>::type;
+  using pop_back = typename detail::pop_back_impl<L>::type;
 }

--- a/brigand/detail/last_element.hpp
+++ b/brigand/detail/last_element.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <brigand/append.hpp>
+
+namespace brigand { namespace detail
+{
+  template <template <class...> class L, class First, class... R>
+  struct without_last_element
+  {
+    using type = append<L<First>, typename without_last_element<L, R...>::type>;
+  };
+
+  template <template <class...> class L, class Last>
+  struct without_last_element<L, Last>
+  {
+    using type = empty_list;
+  };
+
+  // Provides fast-lane for 1-8 elements
+  template <class... R> struct last_element;
+
+  template <class T0>
+  struct last_element<T0>
+  {
+    using type = T0;
+  };
+
+  template <class T0,class T1>
+  struct last_element<T0,T1>
+  {
+    using type = T1;
+  };
+
+  template <class T0,class T1,class T2>
+  struct last_element<T0,T1,T2>
+  {
+    using type = T2;
+  };
+
+  template <class T0,class T1,class T2,class T3>
+  struct last_element<T0,T1,T2,T3>
+  {
+    using type = T3;
+  };
+
+  template <class T0,class T1,class T2,class T3,class T4>
+  struct last_element<T0,T1,T2,T3,T4>
+  {
+    using type = T4;
+  };
+
+  template <class T0,class T1,class T2,class T3,class T4,class T5>
+  struct last_element<T0,T1,T2,T3,T4,T5>
+  {
+    using type = T5;
+  };
+
+  template <class T0,class T1,class T2,class T3,class T4,class T5,class T6>
+  struct last_element<T0,T1,T2,T3,T4,T5,T6>
+  {
+    using type = T6;
+  };
+
+  template <class T0,class T1,class T2,class T3,class T4,class T5,class T6,class T7>
+  struct last_element<T0,T1,T2,T3,T4,T5,T6,T7>
+  {
+    using type = T7;
+  };
+
+  template <class T0,class T1,class T2,class T3,class T4,class T5,class T6,class T7,class... R>
+  struct last_element<T0,T1,T2,T3,T4,T5,T6,T7,R...>
+  {
+    using type = typename last_element<R...>::type;
+  };
+} }


### PR DESCRIPTION
- Unroll last_element from  1 to 8 types
- move implementation to detail/ folder
