### PR TITLE
XOR is the same as !=

### DIFF
--- a/brigand/functions/xor.hpp
+++ b/brigand/functions/xor.hpp
@@ -11,6 +11,6 @@ namespace brigand
 {
   template <typename A, typename B>
   using xor_ = std::integral_constant < typename A::value_type
-                                      , (!A::value && B::value) || (A::value && !B::value)
+                                      , A::value != B::value
                                       >;
 }


### PR DESCRIPTION
(A xor B) == ((!A && B) || (A && !B) == (A != B)
The last one is much cheaper because it's just one operation compared to five of the trivial solution.