### PR TITLE
More test in Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,63 @@
+sudo: false
 language: cpp
 
-compiler:
-  - gcc
-  - clang
+# More complete test matrix
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-4.8']
+      env: TOOLSET=g++-4.8
 
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-4.9']
+      env: TOOLSET=g++-4.9
+
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-5']
+      env: TOOLSET=g++-5
+
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5']
+          packages: ['clang-3.5']
+      env: TOOLSET=clang++-3.5
+
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
+          packages: ['clang-3.6']
+      env: TOOLSET=clang++-3.6
+
+# Install boost
 before_install:
- - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
- - sudo apt-get update -qq
  - wget http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2/download -O /tmp/boost.tar.bz2
  - tar jxf /tmp/boost.tar.bz2
  - mv boost_1_58_0 $PWD/boost-trunk
  - export BOOST_ROOT="$PWD/boost-trunk"
  - cd $TRAVIS_BUILD_DIR
 
-install:
-  - sudo apt-get install -qq gcc-4.8 g++-4.8
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-
+# Prepare build
 before_script:
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake .. -DCMAKE_CXX_COMPILER=$TOOLSET
 
 script:
   - make VERBOSE=1
   - ./brigand_test
-
-os:
-  - linux


### PR DESCRIPTION
Make travis use container based test so we can start tests faster and use new compiler packages easily. N Tests Matrix includes 2 flavors of clang and 3 flavor of g++