### PR TITLE
Master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,13 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcxx-exceptions")
 endif()
 
-find_package(Boost REQUIRED)
+find_package(Boost)
 
 if(Boost_FOUND)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS})
 else()
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBRIGAND_NO_BOOST_SUPPORT")
 endif()
 
 # Install pre-commit git hook

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,6 @@ set(test_files
     test/find.cpp
     test/fold.cpp
     test/for_each.cpp
-    test/fusion_test.cpp
     test/identity.cpp
     test/include_test.cpp
     test/integral_list_test.cpp
@@ -251,7 +250,10 @@ set(test_files
   )
 
 if(Boost_FOUND)
-    set(test_files ${test_files} test/variant_test.cpp)
+    set(test_files 
+    ${test_files} 
+    test/variant_test.cpp
+    test/fusion_test.cpp)
 endif()
 
 source_group(tests FILES ${test_files})


### PR DESCRIPTION
I would like to use brigand in a bare metal embedded environment (think 16k RAM) where boost is not an option. 
It looks like you have provided a path without boost but not concequentially. 
With these changes I am able to use brigand without boost (hopefully) without breaking anybody elses builds.