### PR TITLE
Add .clang-format config file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle: LLVM
+
+AccessModifierOffset: -4
+BreakBeforeBraces: Allman
+ColumnLimit: 100
+IndentWidth: 4
+NamespaceIndentation: Inner
+PointerAlignment: Middle
+TabWidth: 4
+UseTab: Never


### PR DESCRIPTION
Fixes issue #97.
It's hard to write a config file that will correspond to the existing codebase, because its formatting is not consistent.
VS extension available here: http://llvm.org/builds/