### PR TITLE
Rename `remove` -> `remove_if` and `remove_element` -> `remove`.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,7 @@
 BasedOnStyle: LLVM
 
 AccessModifierOffset: -4
+AlwaysBreakTemplateDeclarations: true
 BreakBeforeBraces: Allman
 ColumnLimit: 100
 IndentWidth: 4

--- a/brigand/algorithms/remove.hpp
+++ b/brigand/algorithms/remove.hpp
@@ -51,12 +51,11 @@ namespace brigand
 namespace lazy
 {
     template<typename L, typename Pred>
-    using remove = typename detail::remove_if_impl<L, Pred>;
+    using remove_if = typename detail::remove_if_impl<L, Pred>;
 }
 
-    template<typename L, typename Pred>
-    using remove = typename ::brigand::lazy::remove<L, Pred>::type;
-
+template <typename L, typename Pred>
+using remove_if = typename ::brigand::lazy::remove_if<L, Pred>::type;
 
 namespace detail
 {
@@ -81,12 +80,11 @@ namespace detail
 
 namespace lazy
 {
-    template<typename L, typename T>
-    using remove_element = typename detail::remove_element_impl<L, T>;
+    template <typename L, typename T>
+    using remove = typename detail::remove_element_impl<L, T>;
 }
 
-
-template<typename L, typename T>
-using remove_element = typename ::brigand::lazy::remove_element<L, T>::type;
+template <typename L, typename T>
+using remove = typename ::brigand::lazy::remove<L, T>::type;
 
 }

--- a/standalone/brigand.hpp
+++ b/standalone/brigand.hpp
@@ -1135,10 +1135,10 @@ namespace brigand
 namespace lazy
 {
     template<typename L, typename Pred>
-    using remove = typename detail::remove_if_impl<L, Pred>;
+    using remove_if = typename detail::remove_if_impl<L, Pred>;
 }
-    template<typename L, typename Pred>
-    using remove = typename ::brigand::lazy::remove<L, Pred>::type;
+template <typename L, typename Pred>
+using remove_if = typename ::brigand::lazy::remove_if<L, Pred>::type;
 namespace detail
 {
     template< typename L1, typename T, typename L2 = clear<L1>>
@@ -1159,11 +1159,11 @@ namespace detail
 }
 namespace lazy
 {
-    template<typename L, typename T>
-    using remove_element = typename detail::remove_element_impl<L, T>;
+    template <typename L, typename T>
+    using remove = typename detail::remove_element_impl<L, T>;
 }
-template<typename L, typename T>
-using remove_element = typename ::brigand::lazy::remove_element<L, T>::type;
+template <typename L, typename T>
+using remove = typename ::brigand::lazy::remove<L, T>::type;
 }
 #include <type_traits>
 #if defined(_MSC_VER) && (_MSC_VER < 1900)

--- a/test/remove_test.cpp
+++ b/test/remove_test.cpp
@@ -1,52 +1,40 @@
 #include <brigand/algorithms/remove.hpp>
-#include <brigand/sequences/list.hpp>
-#include <brigand/functions/logical/not.hpp>
 #include <brigand/functions/logical/and.hpp>
-#include <brigand/types/integer.hpp>
-#include <brigand/types/bool.hpp>
+#include <brigand/functions/logical/not.hpp>
+#include <brigand/sequences/list.hpp>
 #include <brigand/types/args.hpp>
+#include <brigand/types/bool.hpp>
+#include <brigand/types/integer.hpp>
 
 using remove_test_list = brigand::list<int, bool, int, char, float, double>;
-using remove_test_int_list = brigand::integral_list<std::uint32_t,1,0,0,2>;
+using remove_test_int_list = brigand::integral_list<std::uint32_t, 1, 0, 0, 2>;
 
-static_assert ( std::is_same< brigand::remove_element<remove_test_int_list, brigand::uint32_t<2>>
-                            , brigand::integral_list<std::uint32_t,1,0,0>
-                            >::value
-              , "invalid remove result"
-              );
+static_assert(std::is_same<brigand::remove<remove_test_int_list, brigand::uint32_t<2>>,
+                           brigand::integral_list<std::uint32_t, 1, 0, 0>>::value,
+              "invalid remove result");
 
-static_assert ( std::is_same< brigand::remove<remove_test_int_list, brigand::not_<brigand::_1>>
-                            , brigand::list<brigand::uint32_t<1>, brigand::uint32_t<2>>
-                            >::value
-              , "invalid remove result"
-              );
+static_assert(std::is_same<brigand::remove_if<remove_test_int_list, brigand::not_<brigand::_1>>,
+                           brigand::list<brigand::uint32_t<1>, brigand::uint32_t<2>>>::value,
+              "invalid remove_if result");
 
-static_assert ( std::is_same< brigand::remove < remove_test_int_list
-                                              , std::is_same<brigand::_1, brigand::uint32_t<2>>
-                                              >
-                            , brigand::integral_list<std::uint32_t,1,0,0>
-                            >::value
-              , "invalid remove_if result"
-              );
+static_assert(std::is_same<brigand::remove_if<remove_test_int_list,
+                                              std::is_same<brigand::_1, brigand::uint32_t<2>>>,
+                           brigand::integral_list<std::uint32_t, 1, 0, 0>>::value,
+              "invalid remove_if result");
 
-static_assert(std::is_same < brigand::remove < remove_test_int_list,
-  brigand::and_ < brigand::_1, brigand::_1 >> ,
-  brigand::integral_list<std::uint32_t, 0, 0>> ::value, "invalid remove result");
+static_assert(
+    std::is_same<brigand::remove_if<remove_test_int_list, brigand::and_<brigand::_1, brigand::_1>>,
+                 brigand::integral_list<std::uint32_t, 0, 0>>::value,
+    "invalid remove_if result");
 
-static_assert ( std::is_same< brigand::remove_element<remove_test_list, int>
-                            , brigand::list<bool, char, float, double>
-                            >::value
-              , "invalid remove result"
-              );
+static_assert(std::is_same<brigand::remove<remove_test_list, int>,
+                           brigand::list<bool, char, float, double>>::value,
+              "invalid remove result");
 
-static_assert ( std::is_same<brigand::remove_element<remove_test_list, double>
-                            , brigand::list<int, bool, int, char, float>
-                            >::value
-              , "invalid remove result"
-              );
+static_assert(std::is_same<brigand::remove<remove_test_list, double>,
+                           brigand::list<int, bool, int, char, float>>::value,
+              "invalid remove result");
 
-static_assert ( std::is_same< brigand::remove<remove_test_list, std::is_same<double, brigand::_1>>
-                            , brigand::list<int, bool, int, char, float>
-                            >::value
-              , "invalid remove_if result"
-              );
+static_assert(std::is_same<brigand::remove_if<remove_test_list, std::is_same<double, brigand::_1>>,
+                           brigand::list<int, bool, int, char, float>>::value,
+              "invalid remove_if result");


### PR DESCRIPTION
This fixes issue #100.

Fix clang-format to always break line after `template <...>`.
Update standalone.