### PR TITLE
Change `next` and `prev` from types to type aliases

### DIFF
--- a/brigand/functions/arithmetic/next.hpp
+++ b/brigand/functions/arithmetic/next.hpp
@@ -10,5 +10,5 @@
 namespace brigand
 {
   template <typename A>
-  struct next : std::integral_constant < typename A::value_type, A::value + 1 > {};
+  using next = std::integral_constant < typename A::value_type, A::value + 1 >;
 }

--- a/brigand/functions/arithmetic/prev.hpp
+++ b/brigand/functions/arithmetic/prev.hpp
@@ -10,5 +10,5 @@
 namespace brigand
 {
   template <typename A>
-  struct prev : std::integral_constant < typename A::value_type, A::value - 1 > {};
+  using prev = std::integral_constant < typename A::value_type, A::value - 1 >;
 }


### PR DESCRIPTION
When `range` or `make_sequence` of even moderate size are used with VC++2015U1, the compiler runs out of heap space and fails. Changing `next` and `prev` from structs to type aliases works around the issue and has no direct negative consequences I see other than the inconsistency that these two arithmetic functions are implemented differently than all the others.