### PR TITLE
Add keys_as_sequence and values_as_sequence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set ( BRIGAND_GROUP
 set(ADAPTED_GROUP
     brigand/adapted/fusion.hpp
     brigand/adapted/integral_list.hpp
+    brigand/adapted/list.hpp
     brigand/adapted/pair.hpp
     brigand/adapted/tuple.hpp
     brigand/adapted/fusion.hpp
@@ -161,6 +162,7 @@ set(SEQUENCES_GROUP
     brigand/sequences/back.hpp
     brigand/sequences/front.hpp
     brigand/sequences/last_element.hpp
+    brigand/sequences/keys_as_sequence.hpp
     brigand/sequences/list.hpp
     brigand/sequences/make_sequence.hpp
     brigand/sequences/map.hpp
@@ -168,6 +170,7 @@ set(SEQUENCES_GROUP
     brigand/sequences/range.hpp
     brigand/sequences/size.hpp
     brigand/sequences/set.hpp
+    brigand/sequences/values_as_sequence.hpp
 )
 
 set(TYPES_GROUP
@@ -213,32 +216,34 @@ add_library(brigand
     ${PLACEHOLDER_GROUP})
 
 set(test_files
+    test/always.cpp
     test/apply.cpp
     test/args.cpp
-    test/always.cpp
     test/bind.cpp
     test/bitwise_test.cpp
     test/comparison_test.cpp
+    test/eval_if_test.cpp
     test/find.cpp
     test/flatten.cpp
     test/fold.cpp
     test/for_each.cpp
     test/identity.cpp
+    test/if_test.cpp
     test/include_test.cpp
-    test/integral_list_test.cpp
-    test/integral_test.cpp
-    test/integer.cpp
     test/inherit.cpp
     test/inherit_linearly.cpp
-    test/if_test.cpp
-    test/eval_if_test.cpp
+    test/integer.cpp
+    test/integral_list_test.cpp
+    test/integral_test.cpp
     test/is_placeholder.cpp
     test/is_set_test.cpp
+    test/keys_as_sequence.cpp
     test/list_test.cpp
     test/logical_test.cpp
+    test/main.cpp
     test/make_sequence_test.cpp
     test/map_test.cpp
-    test/main.cpp
+    test/map_test.hpp
     test/pair_test.cpp
     test/partition_test.cpp
     test/predicate_reduction_test.cpp
@@ -252,12 +257,13 @@ set(test_files
     test/reverse_test.cpp
     test/select.cpp
     test/set_test.cpp
-    test/split.cpp
-    test/sort_test.cpp
     test/sizeof.cpp
+    test/sort_test.cpp
+    test/split.cpp
     test/transform.cpp
     test/tuple_test.cpp
     test/unpack.cpp
+    test/values_as_sequence.cpp
   )
 
 if(Boost_FOUND)

--- a/brigand/adapted/list.hpp
+++ b/brigand/adapted/list.hpp
@@ -11,9 +11,19 @@
 
 namespace brigand
 {
-  template <typename... T>
-  using list_wrapper = typename brigand::list<T...>;
+namespace detail
+{
+    template <typename L, template <class...> class Sequence>
+    struct as_sequence_impl
+    {
+        using type = wrap<L, Sequence>;
+    };
+} // namespace detail
 
-  template <typename L>
-  using as_list = wrap<L, list_wrapper>;
-}
+template <typename L, template <class...> class Sequence>
+using as_sequence = typename detail::as_sequence_impl<L, Sequence>::type;
+
+template <typename L>
+using as_list = as_sequence<L, brigand::list>;
+
+} // namespace brigand

--- a/brigand/sequences/keys_as_sequence.hpp
+++ b/brigand/sequences/keys_as_sequence.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <brigand/adapted/list.hpp>
+#include <brigand/algorithms/transform.hpp>
+#include <brigand/functions/lambda/quote.hpp>
+#include <brigand/sequences/set.hpp>
+
+namespace brigand
+{
+namespace detail
+{
+    template <typename Pair>
+    using get_first = typename Pair::first_type;
+} // namespace detail
+
+template <typename Map, template <class...> class Sequence = brigand::set>
+using keys_as_sequence = transform<as_sequence<Map, Sequence>, quote<detail::get_first>>;
+
+} // namespace brigand

--- a/brigand/sequences/values_as_sequence.hpp
+++ b/brigand/sequences/values_as_sequence.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <brigand/adapted/list.hpp>
+#include <brigand/algorithms/transform.hpp>
+#include <brigand/functions/lambda/quote.hpp>
+
+namespace brigand
+{
+namespace detail
+{
+    template <typename Pair>
+    using get_second = typename Pair::second_type;
+} // namespace detail
+
+template <typename Map, template <class...> class Sequence = brigand::list>
+using values_as_sequence = transform<as_sequence<Map, Sequence>, quote<detail::get_second>>;
+
+} // namespace brigand

--- a/standalone/brigand.hpp
+++ b/standalone/brigand.hpp
@@ -47,25 +47,47 @@ namespace brigand
 }
 namespace brigand
 {
+    template <typename M, typename K>
+    using lookup = decltype(M::at(type_<K>{}));
 namespace detail
 {
     template <class... T>
     struct map_impl;
+    template <class K, class... T>
+    struct map_inserter_impl
+    {
+        using index_type = typename K::first_type;
+        using map_type = map_impl<T...>;
+        using find_result = lookup<map_type, index_type>;
+        using type = decltype(map_type::template insert_impl<K>(find_result{}));
+    };
+    template <class... T>
+    struct map_inserter
+    {
+        template <class K, typename U>
+        static map_impl<T...> insert_impl(U);
+        template <class K>
+        static map_impl<T..., K> insert_impl(no_such_type_);
+        template <class K>
+        static typename map_inserter_impl<K, T...>::type insert(type_<K>);
+    };
     template <>
     struct map_impl<>
     {
         template <typename U>
         static no_such_type_ at(U);
+        template <class K>
+        static map_impl<K> insert(type_<K>);
     };
     template <class T0>
-    struct map_impl<T0>
+    struct map_impl<T0> : map_inserter<T0>
     {
         static typename T0::second_type at(type_<typename T0::first_type>);
         template <typename U>
         static no_such_type_ at(U);
     };
     template <class T0, class T1>
-    struct map_impl<T0, T1>
+    struct map_impl<T0, T1> : map_inserter<T0, T1>
     {
         static typename T0::second_type at(type_<typename T0::first_type>);
         static typename T1::second_type at(type_<typename T1::first_type>);
@@ -73,7 +95,7 @@ namespace detail
         static no_such_type_ at(U);
     };
     template <class T0, class T1, class T2>
-    struct map_impl<T0, T1, T2>
+    struct map_impl<T0, T1, T2> : map_inserter<T0, T1, T2>
     {
         static typename T0::second_type at(type_<typename T0::first_type>);
         static typename T1::second_type at(type_<typename T1::first_type>);
@@ -82,7 +104,7 @@ namespace detail
         static no_such_type_ at(U);
     };
     template <class T0, class T1, class T2, class T3>
-    struct map_impl<T0, T1, T2, T3>
+    struct map_impl<T0, T1, T2, T3> : map_inserter<T0, T1, T2, T3>
     {
         static typename T0::second_type at(type_<typename T0::first_type>);
         static typename T1::second_type at(type_<typename T1::first_type>);
@@ -92,7 +114,7 @@ namespace detail
         static no_such_type_ at(U);
     };
     template <class T0, class T1, class T2, class T3, class T4>
-    struct map_impl<T0, T1, T2, T3, T4>
+    struct map_impl<T0, T1, T2, T3, T4> : map_inserter<T0, T1, T2, T3, T4>
     {
         static typename T0::second_type at(type_<typename T0::first_type>);
         static typename T1::second_type at(type_<typename T1::first_type>);
@@ -103,7 +125,7 @@ namespace detail
         static no_such_type_ at(U);
     };
     template <class T0, class T1, class T2, class T3, class T4, class T5>
-    struct map_impl<T0, T1, T2, T3, T4, T5>
+    struct map_impl<T0, T1, T2, T3, T4, T5> : map_inserter<T0, T1, T2, T3, T4, T5>
     {
         static typename T0::second_type at(type_<typename T0::first_type>);
         static typename T1::second_type at(type_<typename T1::first_type>);
@@ -115,7 +137,7 @@ namespace detail
         static no_such_type_ at(U);
     };
     template <class T0, class T1, class T2, class T3, class T4, class T5, class T6>
-    struct map_impl<T0, T1, T2, T3, T4, T5, T6>
+    struct map_impl<T0, T1, T2, T3, T4, T5, T6> : map_inserter<T0, T1, T2, T3, T4, T5, T6>
     {
         static typename T0::second_type at(type_<typename T0::first_type>);
         static typename T1::second_type at(type_<typename T1::first_type>);
@@ -128,7 +150,7 @@ namespace detail
         static no_such_type_ at(U);
     };
     template <class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7>
-    struct map_impl<T0, T1, T2, T3, T4, T5, T6, T7>
+    struct map_impl<T0, T1, T2, T3, T4, T5, T6, T7> : map_inserter<T0, T1, T2, T3, T4, T5, T6, T7>
     {
         static typename T0::second_type at(type_<typename T0::first_type>);
         static typename T1::second_type at(type_<typename T1::first_type>);
@@ -142,7 +164,7 @@ namespace detail
         static no_such_type_ at(U);
     };
     template <class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class... T>
-    struct map_impl<T0, T1, T2, T3, T4, T5, T6, T7, T...>
+    struct map_impl<T0, T1, T2, T3, T4, T5, T6, T7, T...> : map_inserter<T0, T1, T2, T3, T4, T5, T6, T7, T...>
     {
         static typename T0::second_type at(type_<typename T0::first_type>);
         static typename T1::second_type at(type_<typename T1::first_type>);
@@ -162,8 +184,6 @@ namespace detail
 }
     template<class... Ts>
     using map = typename detail::make_map<Ts...>::type;
-    template <typename M, typename K>
-    using lookup = decltype(M::at(type_<K>{}));
 }
 #include <type_traits>
 namespace brigand
@@ -543,10 +563,18 @@ namespace brigand
 }
 namespace brigand
 {
-  template <typename... T>
-  using list_wrapper = typename brigand::list<T...>;
-  template <typename L>
-  using as_list = wrap<L, list_wrapper>;
+namespace detail
+{
+    template <typename L, template <class...> class Sequence>
+    struct as_sequence_impl
+    {
+        using type = wrap<L, Sequence>;
+    };
+}
+template <typename L, template <class...> class Sequence>
+using as_sequence = typename detail::as_sequence_impl<L, Sequence>::type;
+template <typename L>
+using as_list = as_sequence<L, brigand::list>;
 }
 #include <utility>
 namespace brigand
@@ -820,22 +848,32 @@ namespace brigand
 {
 namespace lazy
 {
-    template<typename Sequence, typename Predicate = detail::non_null>
+    template <typename Sequence, typename Predicate = detail::non_null>
     using find = typename detail::find_if_impl<Predicate, Sequence>;
 }
-template<typename Sequence, typename Predicate = detail::non_null>
+template <typename Sequence, typename Predicate = detail::non_null>
 using find = typename ::brigand::lazy::find<Sequence, Predicate>::type;
 namespace lazy
 {
-    template<typename Sequence, typename Predicate = detail::non_null>
-    using reverse_find = ::brigand::lazy::reverse< ::brigand::find< brigand::reverse<Sequence>, Predicate> >;
+    template <typename Sequence, typename Predicate = detail::non_null>
+    using reverse_find =
+        ::brigand::lazy::reverse<::brigand::find<brigand::reverse<Sequence>, Predicate>>;
 }
 template <typename Sequence, typename Predicate = detail::non_null>
 using reverse_find = typename ::brigand::lazy::reverse_find<Sequence, Predicate>::type;
-template<typename Sequence, typename Predicate = detail::non_null>
-using not_found = typename std::is_same<find<Sequence, Predicate>, empty_sequence>::type;
-template<typename Sequence, typename Predicate = detail::non_null>
-using found = bool_<!std::is_same<find<Sequence, Predicate>, empty_sequence>::value>;
+namespace detail
+{
+    template <typename Sequence, typename Predicate>
+    using find_size = size<brigand::find<Sequence, Predicate>>;
+    template <typename Sequence, typename Predicate>
+    using empty_find = bool_<find_size<Sequence, Predicate>::value == 0>;
+    template <typename Sequence, typename Predicate>
+    using non_empty_find = bool_<find_size<Sequence, Predicate>::value != 0>;
+}
+template <typename Sequence, typename Predicate = detail::non_null>
+using not_found = typename detail::empty_find<Sequence, Predicate>;
+template <typename Sequence, typename Predicate = detail::non_null>
+using found = typename detail::non_empty_find<Sequence, Predicate>;
 }
 namespace brigand
 {
@@ -1281,6 +1319,54 @@ namespace brigand
   {
     return std::forward<F>(f);
   }
+}
+namespace brigand
+{
+namespace detail
+{
+    template<typename TOut, typename TCurrent, typename TDelim, typename... Ts>
+    struct split_impl;
+    template<template<typename...> class L, typename... Os, typename... Cs, typename TDelim, typename T, typename... Ts>
+    struct split_impl<L<Os...>, L<Cs...>, TDelim, T, Ts...> :
+        split_impl<L<Os...>, L<Cs..., T>, TDelim, Ts...> {};
+    template<template<typename...> class L, typename... Os, typename... Cs, typename TDelim, typename T>
+    struct split_impl<L<Os...>, L<Cs...>, TDelim, T> {
+        using type = L<Os..., L<Cs..., T>>;
+    };
+    template<template<typename...> class L, typename... Os, typename... Cs, typename TDelim, typename... Ts>
+    struct split_impl<L<Os...>, L<Cs...>, TDelim, TDelim, Ts...> :
+        split_impl<L<Os..., L<Cs...>>, L<>, TDelim, Ts...> {};
+    template<template<typename...> class L, typename... Os, typename... Cs, typename TDelim>
+    struct split_impl<L<Os...>, L<Cs...>, TDelim, TDelim> {
+        using type = L<Os..., L<Cs...>>;
+    };
+    template<template<typename...> class L, typename... Os, typename TDelim, typename... Ts>
+    struct split_impl<L<Os...>, L<>, TDelim, TDelim, Ts...> :
+        split_impl<L<Os...>, L<>, TDelim, Ts...> {};
+    template<template<typename...> class L, typename... Os, typename TDelim>
+    struct split_impl<L<Os...>, L<>, TDelim, TDelim> {
+        using type = L<Os...>;
+    };
+    template<template<typename...> class L, typename... Os, typename TDelim>
+    struct split_impl<L<Os...>, L<>, TDelim> {
+        using type = L<Os...>;
+    };
+    template<typename TList, typename TDelim>
+    struct split_helper;
+    template<template<typename...> class L, typename T, typename... Ts, typename TDelim>
+    struct split_helper<L<T,Ts...>, TDelim> : split_impl<L<>, L<>, TDelim, T, Ts...>{};
+    template<template<typename...> class L, typename... T, typename TDelim>
+    struct split_helper<L<T...>, TDelim> {
+        using type = L<>;
+    };
+}
+namespace lazy
+{
+    template<typename TList, typename TDelim>
+    using split = detail::split_helper<TList, TDelim>;
+}
+template<typename TList, typename TDelim>
+using split = typename lazy::split<TList, TDelim>::type;
 }
 namespace brigand
 {

--- a/test/for_each.cpp
+++ b/test/for_each.cpp
@@ -20,7 +20,7 @@ struct evil
 {
   template< typename U > evil const& operator()(brigand::type_<U>) const {  return *this;  }
 
-  evil& operator, (int) { return *this; } // evel operator coma
+  evil& operator, (int) { return *this; } // evil operator comma
 };
 
 void for_each_test()

--- a/test/keys_as_sequence.cpp
+++ b/test/keys_as_sequence.cpp
@@ -1,0 +1,15 @@
+#include "map_test.hpp"
+
+#include <brigand/sequences/keys_as_sequence.hpp>
+
+brigand::keys_as_sequence<map_of_ten> keys_of_ten =
+    brigand::set<type_one, type_two, type_three, type_four, type_five, type_six, type_seven,
+                 type_eight, type_nine, void>{};
+
+brigand::keys_as_sequence<map_of_ten, brigand::set> keys_of_ten_set =
+    brigand::set<type_one, type_two, type_three, type_four, type_five, type_six, type_seven,
+                 type_eight, type_nine, void>{};
+
+brigand::keys_as_sequence<map_of_ten, brigand::list> keys_of_ten_list =
+    brigand::list<type_one, type_two, type_three, type_four, type_five, type_six, type_seven,
+                  type_eight, type_nine, void>{};

--- a/test/map_test.cpp
+++ b/test/map_test.cpp
@@ -1,3 +1,4 @@
+#include "map_test.hpp"
 
 #include <brigand/sequences/map.hpp>
 #include <brigand/sequences/size.hpp>
@@ -15,16 +16,6 @@ using map_test = brigand::map<brigand::pair<int, bool>, brigand::pair<char, int>
 static_assert(std::is_same<brigand::lookup<map_test, int>, bool>::value, "should be bool");
 static_assert(std::is_same<brigand::lookup<map_test, char>, int>::value, "should be int");
 static_assert(std::is_same<brigand::lookup<map_test, bool>, brigand::no_such_type_>::value, "should be not found");
-
-struct type_one {};
-struct type_two {};
-struct type_three {};
-struct type_four {};
-struct type_five {};
-struct type_six {};
-struct type_seven {};
-struct type_eight {};
-struct type_nine {};
 
 using big_map = brigand::map<
     brigand::pair<type_one, int>,
@@ -52,17 +43,6 @@ static_assert(std::is_same<brigand::at<big_map, void>, float****>::value,       
 static_assert(std::is_same<brigand::at<big_map, bool>, brigand::no_such_type_>::value,   "found in big map!");
 
 // test insertions all the way up to the fast lanes
-
-using pair_one = brigand::pair<type_one, int>;
-using pair_two = brigand::pair<type_two, type_one>;
-using pair_three = brigand::pair<type_three, type_two>;
-using pair_four = brigand::pair<type_four, type_three>;
-using pair_five = brigand::pair<type_five, type_four>;
-using pair_six = brigand::pair<type_six, type_five>;
-using pair_seven = brigand::pair<type_seven, type_six>;
-using pair_eight = brigand::pair<type_eight, type_seven>;
-using pair_nine = brigand::pair<type_nine, type_eight>;
-using pair_ten = brigand::pair<void, float****>;
 
 using map_of_one = brigand::map<pair_one>;
 static_assert(std::is_same<brigand::insert<brigand::map<>, pair_one>, map_of_one>::value, "insertion failed");

--- a/test/map_test.hpp
+++ b/test/map_test.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <brigand/sequences/map.hpp>
+
+struct type_one {};
+struct type_two {};
+struct type_three {};
+struct type_four {};
+struct type_five {};
+struct type_six {};
+struct type_seven {};
+struct type_eight {};
+struct type_nine {};
+
+using pair_one = brigand::pair<type_one, int>;
+using pair_two = brigand::pair<type_two, type_one>;
+using pair_three = brigand::pair<type_three, type_two>;
+using pair_four = brigand::pair<type_four, type_three>;
+using pair_five = brigand::pair<type_five, type_four>;
+using pair_six = brigand::pair<type_six, type_five>;
+using pair_seven = brigand::pair<type_seven, type_six>;
+using pair_eight = brigand::pair<type_eight, type_seven>;
+using pair_nine = brigand::pair<type_nine, type_eight>;
+using pair_ten = brigand::pair<void, float ****>;
+
+using map_of_ten = brigand::map<pair_one, pair_two, pair_three, pair_four, pair_five, pair_six,
+                                pair_seven, pair_eight, pair_nine, pair_ten>;

--- a/test/values_as_sequence.cpp
+++ b/test/values_as_sequence.cpp
@@ -1,0 +1,16 @@
+#include "map_test.hpp"
+
+#include <brigand/sequences/set.hpp>
+#include <brigand/sequences/values_as_sequence.hpp>
+
+brigand::values_as_sequence<map_of_ten> values_of_ten =
+    brigand::list<int, type_one, type_two, type_three, type_four, type_five, type_six, type_seven,
+                  type_eight, float ****>{};
+
+brigand::values_as_sequence<map_of_ten, brigand::list> values_of_ten_list =
+    brigand::list<int, type_one, type_two, type_three, type_four, type_five, type_six, type_seven,
+                  type_eight, float ****>{};
+
+brigand::values_as_sequence<map_of_ten, brigand::set> values_of_ten_set =
+    brigand::set<int, type_one, type_two, type_three, type_four, type_five, type_six, type_seven,
+                 type_eight, float ****>{};


### PR DESCRIPTION
Add `map_keys_list<Map, Sequence = set>`, `map_values_list<Map, Sequence = list>` that returns a Sequence of keys/values of a map.

These are convience functions.
I've added as well `as_sequence<L, Sequence>` that is a generalisation of `as_list<L> = as_sequence<L, list>`.

Names to be discussed.