### PR TITLE
optimized last_element

### DIFF
--- a/brigand/sequences/last_element.hpp
+++ b/brigand/sequences/last_element.hpp
@@ -22,11 +22,13 @@ namespace brigand { namespace detail
     using type = empty_sequence;
   };
 
+  template<class> using voidp = void const *;
+
   template<class T, class... Ts>
   struct last_element
   {
     template<class Us>
-    static Us last(decltype(static_cast<void const*>(static_cast<Ts*>(nullptr)))..., Us*);
+    static Us last(voidp<Ts>..., Us*);
 
     using type = decltype(last(nullptr, static_cast<Ts*>(nullptr)...));
   };

--- a/brigand/sequences/last_element.hpp
+++ b/brigand/sequences/last_element.hpp
@@ -39,4 +39,11 @@ namespace brigand { namespace detail
   {
     using type = T;
   };
+
+  // fix msvc 2013
+  template<class T, class U>
+  struct last_element<T, U>
+  {
+    using type = U;
+  };
 } }

--- a/brigand/sequences/last_element.hpp
+++ b/brigand/sequences/last_element.hpp
@@ -22,60 +22,12 @@ namespace brigand { namespace detail
     using type = empty_sequence;
   };
 
-  // Provides fast-lane for 1-8 elements
-  template <class... R> struct last_element;
-
-  template <class T0>
-  struct last_element<T0>
+  template<class T, class... Ts>
+  struct last_element
   {
-    using type = T0;
-  };
+    template<class Us>
+    static Us last(decltype(static_cast<void const*>(static_cast<Ts*>(nullptr)))..., Us*);
 
-  template <class T0,class T1>
-  struct last_element<T0,T1>
-  {
-    using type = T1;
-  };
-
-  template <class T0,class T1,class T2>
-  struct last_element<T0,T1,T2>
-  {
-    using type = T2;
-  };
-
-  template <class T0,class T1,class T2,class T3>
-  struct last_element<T0,T1,T2,T3>
-  {
-    using type = T3;
-  };
-
-  template <class T0,class T1,class T2,class T3,class T4>
-  struct last_element<T0,T1,T2,T3,T4>
-  {
-    using type = T4;
-  };
-
-  template <class T0,class T1,class T2,class T3,class T4,class T5>
-  struct last_element<T0,T1,T2,T3,T4,T5>
-  {
-    using type = T5;
-  };
-
-  template <class T0,class T1,class T2,class T3,class T4,class T5,class T6>
-  struct last_element<T0,T1,T2,T3,T4,T5,T6>
-  {
-    using type = T6;
-  };
-
-  template <class T0,class T1,class T2,class T3,class T4,class T5,class T6,class T7>
-  struct last_element<T0,T1,T2,T3,T4,T5,T6,T7>
-  {
-    using type = T7;
-  };
-
-  template <class T0,class T1,class T2,class T3,class T4,class T5,class T6,class T7,class... R>
-  struct last_element<T0,T1,T2,T3,T4,T5,T6,T7,R...>
-  {
-    using type = typename last_element<R...>::type;
+    using type = decltype(last(nullptr, static_cast<Ts*>(nullptr)...));
   };
 } }

--- a/brigand/sequences/last_element.hpp
+++ b/brigand/sequences/last_element.hpp
@@ -32,4 +32,11 @@ namespace brigand { namespace detail
 
     using type = decltype(last(nullptr, static_cast<Ts*>(nullptr)...));
   };
+
+  // fix msvc 2013
+  template<class T>
+  struct last_element<T>
+  {
+    using type = T;
+  };
 } }


### PR DESCRIPTION
/usr/bin/time --format="%Es  %Mk" g++-5

```cpp
#include <brigand/sequences/back.hpp>
#include <brigand/sequences/list.hpp>
#include <brigand/sequences/make_sequence.hpp>
#include <brigand/types/integer.hpp>

template<class T> using void_t = T;

template<int N>
constexpr bool test_last_element()
{
  using list = brigand::push_back<brigand::make_sequence<brigand::size_t<0>, N>, int>;
  return brigand::back<list>(1);
}

static_assert(test_last_element<1>(), "");
static_assert(test_last_element<10>(), "");
static_assert(test_last_element<100>(), "");
static_assert(test_last_element<500>(), "");
static_assert(test_last_element<600>(), "");
static_assert(test_last_element<700>(), "");
static_assert(test_last_element<800>(), "");
static_assert(test_last_element<850>(), "");
//old: 0:00.80s  196232k
//new: 0:00.64s  156096k

static_assert(test_last_element<900>(), "");
static_assert(test_last_element<1000>(), "");
static_assert(test_last_element<2000>(), "");
static_assert(test_last_element<3000>(), "");
//old: 0:05.70s  1009680k
//new: 0:03.85s  774852k
```