### PR TITLE
map::alter metafunction

### DIFF
--- a/brigand/sequences/at.hpp
+++ b/brigand/sequences/at.hpp
@@ -5,13 +5,16 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 =================================================================================================**/
 #pragma once
-#include <brigand/sequences/map.hpp>
 #include <brigand/sequences/filled_list.hpp>
 #include <brigand/sequences/list.hpp>
 #include <brigand/types/type.hpp>
 
 namespace brigand
 {
+  template <typename M, typename K>
+  using lookup = decltype(M::at(type_<K>{}));
+
+
   namespace detail
   {
     template<typename T> struct element_at;

--- a/test/map_test.cpp
+++ b/test/map_test.cpp
@@ -4,6 +4,7 @@
 #include <brigand/sequences/size.hpp>
 #include <brigand/sequences/at.hpp>
 #include <brigand/sequences/insert.hpp>
+#include <brigand/functions/lambda/quote.hpp>
 
 static_assert(brigand::detail::has_at_method<brigand::map<>>::value, "at not detected!");
 
@@ -96,3 +97,54 @@ static_assert(std::is_same<brigand::insert<big_map, pair_seven>, big_map>::value
 static_assert(std::is_same<brigand::insert<big_map, pair_eight>, big_map>::value, "insertion failed");
 static_assert(std::is_same<brigand::insert<big_map, pair_nine>, big_map>::value, "insertion failed");
 static_assert(std::is_same<brigand::insert<big_map, pair_ten>, big_map>::value, "insertion failed");
+
+//
+static_assert(std::is_same<brigand::alter<map_test, int, brigand::quote<std::add_pointer> >,
+                           brigand::map< brigand::pair<int, bool*>, brigand::pair<char,int> > >::value, "alter failed");
+
+static_assert(std::is_same<brigand::alter<map_test, long, brigand::quote<std::add_pointer> >,
+                           brigand::map< brigand::pair<int, bool>, brigand::pair<char,int>, brigand::pair<long,brigand::no_such_type_*> > >::value, "alter failed");
+
+static_assert(std::is_same<brigand::alter<big_map, type_seven, brigand::quote<std::add_pointer> >,
+                           brigand::map<
+                                brigand::pair<type_one, int>,
+                                brigand::pair<type_two, type_one>,
+                                brigand::pair<type_three, type_two>,
+                                brigand::pair<type_four, type_three>,
+                                brigand::pair<type_five, type_four>,
+                                brigand::pair<type_six, type_five>,
+                                brigand::pair<type_seven, type_six*>,
+                                brigand::pair<type_eight, type_seven>,
+                                brigand::pair<type_nine, type_eight>,
+                                brigand::pair<void, float****>
+                           >
+                    >::value, "alter failed");
+
+struct remove_type_three
+{
+    template<class T, class = void>
+    struct apply
+    {
+        typedef T type;
+    };
+
+    template<class X>
+    struct apply<type_three, X>
+    {
+        typedef brigand::no_such_type_ type;
+    };
+};
+
+static_assert(std::is_same<brigand::alter<big_map, type_four, remove_type_three >,
+                           brigand::map<
+                                brigand::pair<type_one, int>,
+                                brigand::pair<type_two, type_one>,
+                                brigand::pair<type_three, type_two>,
+                                brigand::pair<type_five, type_four>,
+                                brigand::pair<type_six, type_five>,
+                                brigand::pair<type_seven, type_six>,
+                                brigand::pair<type_eight, type_seven>,
+                                brigand::pair<type_nine, type_eight>,
+                                brigand::pair<void, float****>
+                           >
+                    >::value, "alter failed");

--- a/test/remove_test.cpp
+++ b/test/remove_test.cpp
@@ -11,7 +11,8 @@
 #include <brigand/types/args.hpp>
 #include <brigand/types/bool.hpp>
 #include <brigand/types/bool.hpp>
-#include <brigand/types/integer.hpp>#include <brigand/algorithms/remove.hpp>
+#include <brigand/types/integer.hpp>
+#include <brigand/algorithms/remove.hpp>
 #include <brigand/types/integer.hpp>
 
 using remove_test_list = brigand::list<int, bool, int, char, float, double>;


### PR DESCRIPTION
Dear all,

This pull request implements an `alter<Map, Key,MetaFunctionClass>` metafunction, similar to the [haskell equivalent](https://downloads.haskell.org/~ghc/6.12.2/docs/html/libraries/containers-0.3.0.0/Data-Map.html#6). I personally need that for a certain dimensional-analysis library I am working on, but I think it should be here for everyone.
I am not particularly fond of this implementation, this PR is more about starting a discussion about the possible ways to implement `alter` (if you feel it is needed at all).

Shortly, `alter< Map, Key, F >` is equivalent to:
>`N  = F<lookup<Map, Key> >`. 
>If `N` is `no_such_type_`
>>If  `Key` is in the map, remove `Key` from the map.
>> Else no effect.

>Else

>> If `Key` is in the map, update the value of `Key` with `N`
>> Else  insert `pair<Key,N>` in the map.


--------------------------

Issues:

* `map.hpp` now needs `apply.hpp`, which needs `at.hpp` which in turn needs `map.hpp`. As a workaround I moved `lookup` into `at.hpp` so that `at.hpp` does not need `map.hpp` anymore (this can probably break some user code).

* It seems to be possible to do  `insert<map, pair<int, no_such_type_>>`, but there is no way to use `alter` to obtain `no_such_type_` as a value of some key,. 
IMO this is a good thing, since in the map context `no_such_type_` means no entry, but we should probably `static_assert` this invariant in `make_map` and `insert`.

* If I am not mistaken, before this PR, the only requirement for the `Ts...` in `map<Ts...>` was to have the member typedefs `first_type` and `second_type`. Now every `Ts` also needs to match a `template<class, class> class Pair` specialization. This is needed so that `alter` can use the same type on modification:
    `alter< map< std::pair<int, int> >, int, quote<add_pointer> >` is `map<std::pair<int, int*> >` and not `map< brigand::pair<int, int*> >`. Not sure if this is a good idea, because `brigand::pair` is already special since I fallback to it when the key is not present.
Possible design I can think of:

   * This PR (i.e. both `first_type` and `second_type` member typedefs + being a class template with exactly two type arguments)
   * Only allow `brigand::pair` types in the `map` parameter list.
   * Remove the requirement on `first_type` and `second_type` and use some traits type to extract those when required (`brigand::first_type<>`, `brigand::second_type<>`, and maybe allow the user to specialize those?)
   * Keep the requirement on `first_type` and `second_type`, but have the `F` in the combiner take both a key and a value as a parameter and let the writer of the `F` decide if he/she wants `brigand::pair`, `std::pair` or whatever.

Best regards!
Ennio