### PR TITLE
optimized brigand::is_set

### DIFF
--- a/brigand/algorithms/is_set.hpp
+++ b/brigand/algorithms/is_set.hpp
@@ -6,45 +6,41 @@
 =================================================================================================**/
 #pragma once
 
-#include <brigand/sequences/make_sequence.hpp>
-#include <brigand/types/integer.hpp>
+#include <initializer_list>
+
+#include <brigand/sequences/range.hpp>
 #include <brigand/types/type.hpp>
 
 namespace brigand
 {
 namespace detail
 {
-  template<class Ints, class...T>
-  struct is_set_impl
-  {
-    template<class U>
-    static std::true_type is_set(U);
-
-    static std::true_type is_set();
-  };
-
-  template<class, class T>
-  struct unique_x_t
+  template<int, class T> struct unique_x_t
+  // :type_<T> // best with g++
   { operator type_<T> (); };
 
-  template<class... T>
-  struct unique_set : T... {};
+  template<class Ints, class... Ts>
+  struct is_set_impl;
 
-  template<class Int, class... Ints, class L, class... R>
-  struct is_set_impl<list<Int, Ints...>, L, R...>
+  template<>
+  struct is_set_impl<list<>>
   {
-    template<class U, class = decltype(static_cast<type_<U>>(unique_set<unique_x_t<Int, L>, unique_x_t<Ints, R>...>()))>
-    static std::false_type is_set(type_<U>);
+    using type = std::true_type;
+  };
 
-    template<class U>
-    static decltype(is_set_impl<list<Ints...>, R...>::is_set(type_<L>()))
-    is_set(U);
+  template<int... Ints, class... Ts>
+  struct is_set_impl<list<std::integral_constant<int, Ints>...>, Ts...>
+  {
+    struct Pack : unique_x_t<Ints, Ts>... {};
 
-    static decltype(is_set_impl<list<Ints...>, R...>::is_set(type_<L>()))
-    is_set(...);
+    template<class... Us>
+    static auto is_set(Us...) -> decltype(std::initializer_list<int>{(static_cast<Us>(Pack()), 1)...}, std::true_type{});
+    static std::false_type is_set(...);
+
+    using type = decltype(is_set(type_<Ts>()...));
   };
 }
 
-  template <class... T>
-  using is_set = decltype(detail::is_set_impl<make_sequence<uint32_t<0>, sizeof...(T)>, T...>::is_set());
+  template<class... Ts>
+  using is_set = typename detail::is_set_impl<range<int, 0, sizeof...(Ts)>, Ts...>::type;
 }

--- a/brigand/algorithms/is_set.hpp
+++ b/brigand/algorithms/is_set.hpp
@@ -15,7 +15,7 @@ namespace brigand
 {
 namespace detail
 {
-  template<int, class T> struct unique_x_t
+  template<class, class T> struct unique_x_t
   // :type_<T> // best with g++
   { operator type_<T> (); };
 
@@ -28,13 +28,15 @@ namespace detail
     using type = std::true_type;
   };
 
-  template<int... Ints, class... Ts>
-  struct is_set_impl<list<std::integral_constant<int, Ints>...>, Ts...>
+  std::true_type true_fn(...);
+
+  template<class... Ints, class... Ts>
+  struct is_set_impl<list<Ints...>, Ts...>
   {
     struct Pack : unique_x_t<Ints, Ts>... {};
 
     template<class... Us>
-    static auto is_set(Us...) -> decltype(std::initializer_list<int>{(static_cast<Us>(Pack()), 1)...}, std::true_type{});
+    static auto is_set(Us...) -> decltype(true_fn(static_cast<Us>(Pack())...));
     static std::false_type is_set(...);
 
     using type = decltype(is_set(type_<Ts>()...));

--- a/brigand/algorithms/is_set.hpp
+++ b/brigand/algorithms/is_set.hpp
@@ -6,8 +6,6 @@
 =================================================================================================**/
 #pragma once
 
-#include <initializer_list>
-
 #include <brigand/sequences/range.hpp>
 #include <brigand/types/type.hpp>
 

--- a/brigand/algorithms/is_set.hpp
+++ b/brigand/algorithms/is_set.hpp
@@ -16,7 +16,7 @@ namespace brigand
 namespace detail
 {
   template<class, class T> struct unique_x_t
-  // :type_<T> // best with g++
+  // :type_<T> // better with gcc, very bad with clang when the list contains many same elements
   { operator type_<T> (); };
 
   template<class Ints, class... Ts>
@@ -28,7 +28,7 @@ namespace detail
     using type = std::true_type;
   };
 
-  std::true_type true_fn(...);
+  inline std::true_type true_fn(...);
 
   template<class... Ints, class... Ts>
   struct is_set_impl<list<Ints...>, Ts...>


### PR DESCRIPTION
`//list<int, int, int, ...>`
`using list = brigand::wrap<brigand::filled_list<int, N_L1>, brigand::is_set>;`

Before:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.07s - 37M | 00.11s - 40M | 00.22s - 46M | 00.56s - 66M | ko
gcc | 00.06s - 21M | 00.12s - 31M | 00.29s - 52M | 01.09s - 122M | 05.95s - 373M

After:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.05s - 36M | 00.06s - 36M | 00.06s - 37M | 00.07s - 38M | 00.08s - 39M
gcc | 00.04s - 19M | 00.04s - 19M | 00.05s - 21M | 00.07s - 23M | 00.12s - 28M

----

`//list<_1, _2, _3, ...>`
`using list = brigand::wrap<brigand::range<int, 0, N_L1>, brigand::is_set>;`

Before:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.07s - 37M | 00.14s - 40M | 00.40s - 47M | 02.14s - 67M | ko
gcc | 00.06s - 22M | 00.13s - 33M | 00.32s - 56M | 01.22s - 135M | 06.46s - 417M

After:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.05s - 35M | 00.06s - 36M | 00.09s - 37M | 00.17s - 39M | 00.49s - 43M
gcc | 00.04s - 19M | 00.06s - 22M | 00.10s - 28M | 00.23s - 49M | 00.73s - 122M

----

`//list<int, int, ..., _1, _2, _3, ...>`
`using list = brigand::wrap<brigand::append<brigand::filled_list<int, N_L1/2>, brigand::range<int, 0, N_L1/2>>, brigand::is_set>;`

Before:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.07s - 37M | 00.12s - 40M | 00.23s - 46M | 00.69s - 66M | ko
gcc | 00.06s - 22M | 00.13s - 32M | 00.31s - 54M | 01.14s - 126M | 06.17s - 386M

After:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.05s - 35M | 00.06s - 36M | 00.06s - 37M | 00.07s - 38M | 00.09s - 40M
gcc | 00.04s - 19M | 00.05s - 20M | 00.05s - 22M | 00.08s - 25M | 00.13s - 31M