### PR TITLE
removed unnecessary call to std::ref

### DIFF
--- a/brigand/algorithms/for_each_args.hpp
+++ b/brigand/algorithms/for_each_args.hpp
@@ -7,12 +7,11 @@
 #pragma once
 
 #include <initializer_list>
-#include <functional>
 
 namespace brigand
 {
   template<class F, class...Ts> F for_each_args(F f, Ts&&...a)
   {
-    return (void)std::initializer_list<int>{((void)std::ref(f)(static_cast<Ts&&>(a)),0)...}, f;
+    return (void)std::initializer_list<int>{((void)f(static_cast<Ts&&>(a)),0)...}, f;
   }
 }


### PR DESCRIPTION
Evaluation order is guaranteed even without std::ref