### PR TITLE
optimized brifand::fold on gcc

### DIFF
--- a/brigand/algorithms/detail/fold.hpp
+++ b/brigand/algorithms/detail/fold.hpp
@@ -12,117 +12,157 @@
 namespace brigand { namespace detail
 {
 
-  template <class Functor, class State, class Sequence>
+  template<class Functor, class State, class Sequence>
   struct fold_impl
   {
-    using type = State;
+      using type = State;
   };
 
-  template <class Functor, class State, template <class...> class Sequence,
-            typename T0>
+  template<
+      class Functor, class State, template <class...> class Sequence,
+      class T0>
   struct fold_impl<Functor, State, Sequence<T0>>
   {
-    using type = typename brigand::apply<Functor, State, T0>;
+      using type = brigand::apply<Functor, State, T0>;
   };
-
-  template <class Functor, class State, template <class...> class Sequence,
-            typename T0, typename T1>
+ 
+  template<
+      class Functor, class State, template <class...> class Sequence,
+      class T0, class T1>
   struct fold_impl<Functor, State, Sequence<T0, T1>>
   {
-      using state0 = typename brigand::apply<Functor, State, T0>;
-
-      using type = typename brigand::apply<Functor, state0, T1>;
+      using type = brigand::apply<Functor,
+          brigand::apply<Functor,State, T0>, T1
+      >;
   };
 
-  template <class Functor, class State, template <class...> class Sequence,
-            typename T0, typename T1, typename T2>
+  template<
+      class Functor, class State, template <class...> class Sequence,
+      class T0, class T1, class T2>
   struct fold_impl<Functor, State, Sequence<T0, T1, T2>>
   {
-      using state0 = typename brigand::apply<Functor, State, T0>;
-      using state1 = typename brigand::apply<Functor, state0, T1>;
-
-      using type = typename brigand::apply<Functor, state1, T2>;
+      using type = brigand::apply<Functor,
+          brigand::apply<Functor,
+              brigand::apply<Functor, State, T0>, T1
+          >, T2
+      >;
   };
 
-  template <class Functor, class State, template <class...> class Sequence,
-            typename T0, typename T1, typename T2, typename T3>
+  template<
+      class Functor, class State, template <class...> class Sequence,
+      class T0, class T1, class T2, class T3>
   struct fold_impl<Functor, State, Sequence<T0, T1, T2, T3>>
   {
-      using state0 = typename brigand::apply<Functor, State, T0>;
-      using state1 = typename brigand::apply<Functor, state0, T1>;
-      using state2 = typename brigand::apply<Functor, state1, T2>;
-
-      using type = typename brigand::apply<Functor, state2, T3>;
+      using type = brigand::apply<Functor,
+          brigand::apply<Functor, 
+              brigand::apply<Functor,
+                  brigand::apply<Functor, State, T0>, T1
+              >, T2
+          >, T3
+      >;
   };
 
-  template <class Functor, class State, template <class...> class Sequence,
-            typename T0, typename T1, typename T2, typename T3, typename T4>
+  template<
+      class Functor, class State, template <class...> class Sequence,
+      class T0, class T1, class T2, class T3, class T4>
   struct fold_impl<Functor, State, Sequence<T0, T1, T2, T3, T4>>
   {
-      using state0 = typename brigand::apply<Functor, State, T0>;
-      using state1 = typename brigand::apply<Functor, state0, T1>;
-      using state2 = typename brigand::apply<Functor, state1, T2>;
-      using state3 = typename brigand::apply<Functor, state2, T3>;
-
-      using type = typename brigand::apply<Functor, state3, T4>;
+      using type = brigand::apply<Functor,
+          brigand::apply<Functor,
+              brigand::apply<Functor,
+                  brigand::apply<Functor,
+                      brigand::apply<Functor, State, T0>, T1
+                  >, T2
+              >, T3
+          >, T4
+      >;
   };
 
-  template <class Functor, class State, template <class...> class Sequence,
-            typename T0, typename T1, typename T2, typename T3, typename T4, typename T5>
+  template<
+      class Functor, class State, template <class...> class Sequence,
+      class T0, class T1, class T2, class T3, class T4, class T5>
   struct fold_impl<Functor, State, Sequence<T0, T1, T2, T3, T4, T5>>
   {
-      using state0 = typename brigand::apply<Functor, State, T0>;
-      using state1 = typename brigand::apply<Functor, state0, T1>;
-      using state2 = typename brigand::apply<Functor, state1, T2>;
-      using state3 = typename brigand::apply<Functor, state2, T3>;
-      using state4 = typename brigand::apply<Functor, state3, T4>;
-
-      using type = typename brigand::apply<Functor, state4, T5>;
+      using type = brigand::apply<Functor,
+          brigand::apply<Functor,
+              brigand::apply<Functor,
+                  brigand::apply<Functor,
+                      brigand::apply<Functor,
+                          brigand::apply<Functor, State, T0>, T1
+                      >, T2
+                  >, T3
+              >, T4
+          >, T5
+      >;
   };
 
-  template <class Functor, class State, template <class...> class Sequence,
-      typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  template<
+      class Functor, class State, template <class...> class Sequence,
+      class T0, class T1, class T2, class T3, class T4, class T5, class T6>
   struct fold_impl<Functor, State, Sequence<T0, T1, T2, T3, T4, T5, T6>>
   {
-      using state0 = typename brigand::apply<Functor, State, T0>;
-      using state1 = typename brigand::apply<Functor, state0, T1>;
-      using state2 = typename brigand::apply<Functor, state1, T2>;
-      using state3 = typename brigand::apply<Functor, state2, T3>;
-      using state4 = typename brigand::apply<Functor, state3, T4>;
-      using state5 = typename brigand::apply<Functor, state4, T5>;
-
-      using type = typename brigand::apply<Functor, state5, T6>;
+      using type = brigand::apply<Functor,
+          brigand::apply<Functor,
+              brigand::apply<Functor,
+                  brigand::apply<Functor,
+                      brigand::apply<Functor,
+                          brigand::apply<Functor,
+                              brigand::apply<Functor, State, T0>, T1
+                          >, T2
+                      >, T3
+                  >, T4
+              >, T5
+          >, T6
+      >;
   };
 
-  template <class Functor, class State, template <class...> class Sequence,
-      typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+  template<
+      class Functor, class State, template <class...> class Sequence,
+      class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7>
   struct fold_impl<Functor, State, Sequence<T0, T1, T2, T3, T4, T5, T6, T7>>
   {
-      using state0 = typename brigand::apply<Functor, State, T0>;
-      using state1 = typename brigand::apply<Functor, state0, T1>;
-      using state2 = typename brigand::apply<Functor, state1, T2>;
-      using state3 = typename brigand::apply<Functor, state2, T3>;
-      using state4 = typename brigand::apply<Functor, state3, T4>;
-      using state5 = typename brigand::apply<Functor, state4, T5>;
-      using state6 = typename brigand::apply<Functor, state5, T6>;
-
-      using type = typename brigand::apply<Functor, state6, T7>;
+      using type = brigand::apply<Functor,
+          brigand::apply<Functor,
+              brigand::apply<Functor,
+                  brigand::apply<Functor,
+                      brigand::apply<Functor,
+                          brigand::apply<Functor,
+                              brigand::apply<Functor,
+                                  brigand::apply<Functor, State, T0>, T1
+                              >, T2
+                          >, T3
+                      >, T4
+                  >, T5
+              >, T6
+          >, T7
+      >;
   };
 
-  template <class Functor, class State, template <class...> class Sequence,
-      typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename... T>
+  template<
+      class Functor, class State, template <class...> class Sequence,
+      class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class... T>
   struct fold_impl<Functor, State, Sequence<T0, T1, T2, T3, T4, T5, T6, T7, T...>>
-  {
-      using state0 = typename brigand::apply<Functor, State, T0>;
-      using state1 = typename brigand::apply<Functor, state0, T1>;
-      using state2 = typename brigand::apply<Functor, state1, T2>;
-      using state3 = typename brigand::apply<Functor, state2, T3>;
-      using state4 = typename brigand::apply<Functor, state3, T4>;
-      using state5 = typename brigand::apply<Functor, state4, T5>;
-      using state6 = typename brigand::apply<Functor, state5, T6>;
-      using state7 = typename brigand::apply<Functor, state6, T7>;
-
-      using type = typename fold_impl<Functor, state7, Sequence<T...>>::type;
-  };
+  : fold_impl<
+      Functor,
+      brigand::apply<Functor,
+          brigand::apply<Functor,
+              brigand::apply<Functor,
+                  brigand::apply<Functor,
+                      brigand::apply<Functor,
+                          brigand::apply<Functor,
+                              brigand::apply<Functor,
+                                  brigand::apply<Functor,
+                                      State, T0
+                                  >, T1
+                              >, T2
+                          >, T3
+                      >, T4
+                  >, T5
+              >, T6
+          >, T7
+      >,
+      Sequence<T...>
+  >
+  {};
 
 } }


### PR DESCRIPTION
Tips: Types members impacts the performance of gcc.

----

```cpp
using list = brigand::fold<
  brigand::range<int, 0, N_L1>,
  std::integral_constant<int, 0>,
  brigand::plus<brigand::_state, brigand::_element>
>;
```

Before:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.07s - 37M | 00.10s - 39M | 00.15s - 42M | 00.24s - 49M | 00.44s - 63M
gcc | 00.05s - 21M | 00.10s - 27M | 00.16s - 35M | 00.28s - 53M | 00.55s - 93M

After:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.07s - 36M | 00.10s - 39M | 00.15s - 42M | 00.24s - 49M | 00.44s - 63M
gcc | 00.05s - 21M | 00.10s - 27M | 00.15s - 34M | 00.26s - 50M | 00.50s - 84M
