### PR TITLE
Optimized erase_c with a big index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,7 @@ set(test_files
     test/bitwise_test.cpp
     test/comparison_test.cpp
     test/eval_if_test.cpp
+    test/erase_c_test.cpp
     test/find.cpp
     test/flatten.cpp
     test/fold.cpp

--- a/brigand/sequences/erase.hpp
+++ b/brigand/sequences/erase.hpp
@@ -17,20 +17,12 @@
 
 namespace brigand
 {
-namespace detail
-{
-    template<std::size_t Index, class L>
-    struct erase_c_impl
-    {
-        using type = append<
-            front<split_at<L, size_t<Index>>>,
-            pop_front<back<split_at<L, size_t<Index>>>>
-        >;
-    };
-}
 
     template<class L, std::size_t Index>
-    using erase_c = typename detail::erase_c_impl<Index, L>::type;
+    using erase_c = append<
+        front<split_at<L, size_t<Index>>>,
+        pop_front<back<split_at<L, size_t<Index>>>>
+    >;
 
 namespace detail
 {
@@ -129,11 +121,6 @@ namespace detail
 
 namespace detail
 {
-    template< class L, class Index >
-    struct erase_impl
-    {
-        using type = erase_c<L, Index::value>;
-    };
 
     template< class L1, template<class> class Pred, class L2 >
     struct erase_if_impl;
@@ -188,7 +175,7 @@ namespace detail
     template<class L, class I, bool>
     struct erase_dispatch
     {
-        using type = typename erase_impl<L, I>::type;
+        using type = erase_c<L, I::value>;
     };
 
     template<class C, class K>

--- a/brigand/sequences/erase.hpp
+++ b/brigand/sequences/erase.hpp
@@ -5,33 +5,32 @@
   (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 =================================================================================================**/
 #pragma once
-#include <brigand/sequences/append.hpp>
-#include <brigand/sequences/clear.hpp>
+#include <brigand/algorithms/split_at.hpp>
 
+#include <brigand/sequences/append.hpp>
+#include <brigand/sequences/back.hpp>
+#include <brigand/sequences/front.hpp>
+
+#include <brigand/types/integer.hpp>
 #include <brigand/types/type.hpp>
+
 
 namespace brigand
 {
 namespace detail
 {
-    template<int Index, class L1, class L2>
-    struct erase_c_impl;
-
-    template< int Index,
-            template<class...> class L1, class First, class... T,
-      template<class...> class L2, class... U >
-    struct erase_c_impl<Index, L1<First, T...>, L2<U...>>
+    template<std::size_t Index, class L>
+    struct erase_c_impl
     {
-        using type = typename erase_c_impl<Index-1, L1<T...>, L2<U..., First>>::type;
-    };
-
-    template< template<class...> class L1, class First, class... T,
-            template<class...> class L2, class... U >
-    struct erase_c_impl<0, L1<First, T...>, L2<U...>>
-    {
-        using type = L2<U..., T...>;
+        using type = append<
+            front<split_at<L, size_t<Index>>>,
+            pop_front<back<split_at<L, size_t<Index>>>>
+        >;
     };
 }
+
+    template<class L, std::size_t Index>
+    using erase_c = typename detail::erase_c_impl<Index, L>::type;
 
 namespace detail
 {
@@ -127,9 +126,6 @@ namespace detail
     };
 
 }
-
- template< class L, int Index >
-  using erase_c = typename detail::erase_c_impl<Index, L, clear<L>>::type;
 
 namespace detail
 {

--- a/test/erase_c_test.cpp
+++ b/test/erase_c_test.cpp
@@ -1,0 +1,9 @@
+
+#include <brigand/sequences/erase.hpp>
+#include <brigand/sequences/list.hpp>
+#include <type_traits>
+
+static_assert(std::is_same<brigand::erase_c<brigand::list<int>, 0>, brigand::list<>>::value, "invalid erase_c result");
+static_assert(std::is_same<brigand::erase_c<brigand::list<int, char, bool>, 0>, brigand::list<char, bool>>::value, "invalid erase_c result");
+static_assert(std::is_same<brigand::erase_c<brigand::list<int, char, bool>, 1>, brigand::list<int, bool>>::value, "invalid erase_c result");
+static_assert(std::is_same<brigand::erase_c<brigand::list<int, char, bool>, 2>, brigand::list<int, char>>::value, "invalid erase_c result");


### PR DESCRIPTION
Little extra cost for a small list or a small index.

---

```cpp
using list = brigand::erase_c<brigand::range<int, 0, SIZE>, 0>;
```

Before:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.05s - 35M | 00.06s - 36M | 00.06s - 36M | 00.07s - 36M | 00.07s - 37M
gcc | 00.04s - 19M | 00.04s - 19M | 00.05s - 19M | 00.05s - 20M | 00.06s - 21M

After:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.06s - 36M | 00.07s - 36M | 00.07s - 37M | 00.07s - 37M | 00.08s - 38M
gcc | 00.05s - 20M | 00.05s - 20M | 00.05s - 20M | 00.06s - 21M | 00.07s - 22M

---

```cpp
using list = brigand::erase_c<brigand::range<int, 0, SIZE>, SIZE/2>;
```

Before:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.05s - 35M | 00.06s - 36M | 00.07s - 38M | 00.10s - 42M | 00.19s - 58M
gcc | 00.04s - 19M | 00.05s - 20M | 00.06s - 21M | 00.08s - 26M | 00.17s - 43M

After:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.06s - 36M | 00.07s - 36M | 00.07s - 37M | 00.08s - 38M | 00.10s - 40M
gcc | 00.04s - 20M | 00.05s - 20M | 00.05s - 20M | 00.06s - 21M | 00.08s - 24M

---

```cpp
using list = brigand::erase_c<brigand::range<int, 0, SIZE>, SIZE-1>;
```

Before:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.06s - 35M | 00.07s - 37M | 00.08s - 39M | 00.13s - 48M | ko
gcc | 00.04s - 19M | 00.05s - 20M | 00.06s - 23M | 00.11s - 32M | 00.28s - 65M

After:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.06s - 36M | 00.07s - 37M | 00.07s - 37M | 00.08s - 38M | 00.10s - 42M
gcc | 00.05s - 20M | 00.05s - 20M | 00.06s - 20M | 00.06s - 22M | 00.09s - 26M
