### PR TITLE
optimized make_sequence with gcc

### DIFF
--- a/brigand/sequences/make_sequence.hpp
+++ b/brigand/sequences/make_sequence.hpp
@@ -9,260 +9,63 @@
 #include <brigand/functions/arithmetic/next.hpp>
 #include <brigand/functions/lambda/apply.hpp>
 #include <brigand/functions/lambda/quote.hpp>
+#include <brigand/sequences/append.hpp>
 #include <brigand/sequences/list.hpp>
 
 namespace brigand
 {
 namespace detail
 {
-  template<class Start, unsigned N, class Next, class List>
-  struct make_sequence_impl;
+    template<class Start, unsigned N, class Next, class... E>
+    struct mksq8
+    : mksq8<brigand::apply<Next, Start>, N-1, Next, E..., Start>
+    {};
 
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 0, Next, List<E...>>
-  {
-    using type = List<E...>;
-  };
+    template<class Start, class Next, class... E>
+    struct mksq8<Start, 0, Next, E...>
+    {
+        using type = list<E...>;
+    };
 
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 1, Next, List<E...>>
-  {
-    using type = List<E..., Start>;
-  };
+    template<class Start, class Next, class... E>
+    struct mksq8<Start, 1, Next, E...>
+    {
+        using type = list<E..., Start>;
+    };
 
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 2, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using type = List<E..., Start, t1>;
-  };
+    template<class Start, class Next>
+    struct mksq8<Start, 8, Next>
+    {
+        using t1 = brigand::apply<Next, Start>;
+        using t2 = brigand::apply<Next, t1>;
+        using t3 = brigand::apply<Next, t2>;
+        using t4 = brigand::apply<Next, t3>;
+        using t5 = brigand::apply<Next, t4>;
+        using t6 = brigand::apply<Next, t5>;
+        using t7 = brigand::apply<Next, t6>;
+        using type = list<Start, t1, t2, t3, t4, t5, t6, t7>;
+    };
 
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 3, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using type = List<E..., Start, t1, t2>;
-  };
+    template<template<class...> class List, class Start, unsigned N, class Next, bool, class... L>
+    struct make_sequence_impl
+    : make_sequence_impl<
+        List,
+        brigand::apply<Next, typename mksq8<Start, 8, Next>::t7>,
+        N-8,
+        Next,
+        (N-8<=8),
+        L...,
+        typename mksq8<Start, 8, Next>::type
+    >
+    {};
 
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 4, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using type = List<E..., Start, t1, t2, t3>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 5, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using type = List<E..., Start, t1, t2, t3, t4>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 6, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 7, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 8, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6, t7>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 9, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using t8 = brigand::apply<Next, t7>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6, t7, t8>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 10, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using t8 = brigand::apply<Next, t7>;
-    using t9 = brigand::apply<Next, t8>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6, t7, t8, t9>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 11, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using t8 = brigand::apply<Next, t7>;
-    using t9 = brigand::apply<Next, t8>;
-    using t10 = brigand::apply<Next, t9>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 12, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using t8 = brigand::apply<Next, t7>;
-    using t9 = brigand::apply<Next, t8>;
-    using t10 = brigand::apply<Next, t9>;
-    using t11 = brigand::apply<Next, t10>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 13, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using t8 = brigand::apply<Next, t7>;
-    using t9 = brigand::apply<Next, t8>;
-    using t10 = brigand::apply<Next, t9>;
-    using t11 = brigand::apply<Next, t10>;
-    using t12 = brigand::apply<Next, t11>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 14, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using t8 = brigand::apply<Next, t7>;
-    using t9 = brigand::apply<Next, t8>;
-    using t10 = brigand::apply<Next, t9>;
-    using t11 = brigand::apply<Next, t10>;
-    using t12 = brigand::apply<Next, t11>;
-    using t13 = brigand::apply<Next, t12>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 15, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using t8 = brigand::apply<Next, t7>;
-    using t9 = brigand::apply<Next, t8>;
-    using t10 = brigand::apply<Next, t9>;
-    using t11 = brigand::apply<Next, t10>;
-    using t12 = brigand::apply<Next, t11>;
-    using t13 = brigand::apply<Next, t12>;
-    using t14 = brigand::apply<Next, t13>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14>;
-  };
-
-  template<class Start, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, 16, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using t8 = brigand::apply<Next, t7>;
-    using t9 = brigand::apply<Next, t8>;
-    using t10 = brigand::apply<Next, t9>;
-    using t11 = brigand::apply<Next, t10>;
-    using t12 = brigand::apply<Next, t11>;
-    using t13 = brigand::apply<Next, t12>;
-    using t14 = brigand::apply<Next, t13>;
-    using t15 = brigand::apply<Next, t14>;
-    using type = List<E..., Start, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15>;
-  };
-
-  template<class Start, unsigned N, class Next, template<class...> class List, class... E>
-  struct make_sequence_impl<Start, N, Next, List<E...>>
-  {
-    using t1 = brigand::apply<Next, Start>;
-    using t2 = brigand::apply<Next, t1>;
-    using t3 = brigand::apply<Next, t2>;
-    using t4 = brigand::apply<Next, t3>;
-    using t5 = brigand::apply<Next, t4>;
-    using t6 = brigand::apply<Next, t5>;
-    using t7 = brigand::apply<Next, t6>;
-    using t8 = brigand::apply<Next, t7>;
-    using t9 = brigand::apply<Next, t8>;
-    using t10 = brigand::apply<Next, t9>;
-    using t11 = brigand::apply<Next, t10>;
-    using t12 = brigand::apply<Next, t11>;
-    using t13 = brigand::apply<Next, t12>;
-    using t14 = brigand::apply<Next, t13>;
-    using t15 = brigand::apply<Next, t14>;
-    using t16 = brigand::apply<Next, t15>;
-    using type = typename make_sequence_impl<t16, N-16, Next, List<E..., Start, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15>>::type;
-  };
+    template<template<class...> class List, class Start, unsigned N, class Next, class... L>
+    struct make_sequence_impl<List, Start, N, Next, true, L...>
+    {
+        using type = append<List<>, L..., typename mksq8<Start, N, Next>::type>;
+    };
 }
 
-  template<class Start, unsigned N, class Next = quote<next>, template<class...> class List = list>
-  using make_sequence = typename detail::make_sequence_impl<Start, N, Next, List<>>::type;
+    template<class Start, unsigned N, class Next = quote<next>, template<class...> class List = list>
+    using make_sequence = typename detail::make_sequence_impl<List, Start, N, Next, (N<=8)>::type;
 }


### PR DESCRIPTION
```cpp
using list = brigand::make_sequence<std::integral_constant<int,0>, SIZE>;
```

Before:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.07s - 35M | 00.08s - 36M | 00.09s - 37M | 00.12s - 39M | 00.18s - 43M
gcc | 00.05s - 20M | 00.07s - 23M | 00.10s - 27M | 00.15s - 35M | 00.27s - 55M

After:

Size= | 10 | 50 | 100 | 200 | 400
--- | --- | --- | --- | --- | ---
clang | 00.06s - 35M | 00.07s - 36M | 00.09s - 37M | 00.12s - 39M | 00.18s - 43M
gcc | 00.05s - 20M | 00.06s - 22M | 00.09s - 26M | 00.13s - 32M | 00.22s - 46M
