### PR TITLE
allow reference types in at<...> implementation

### DIFF
--- a/brigand/sequences/at.hpp
+++ b/brigand/sequences/at.hpp
@@ -19,14 +19,14 @@ namespace brigand
     template<class... Ts>
     struct element_at<list<Ts...>>
     {
-      template<class T> type_<T> static at(Ts..., T*, ...);
+      template<class T> type_<T> static at(Ts..., type_<T>*, ...);
     };
 
     template<std::size_t N, typename Seq> struct at_impl;
 
     template<std::size_t N, template<typename...> class L, class... Ts>
     struct at_impl<N,L<Ts...>>
-    : decltype(element_at<brigand::filled_list<void const *, N>>::at(static_cast<Ts*>(nullptr)...))
+    : decltype(element_at<brigand::filled_list<void const *, N>>::at(static_cast<type_<Ts>*>(nullptr)...))
     {
     };
   }


### PR DESCRIPTION
before change, trying to get at<N, List<Ts...>> where Ts... contained one or more reference types would cause a pointer-to-reference error