### PR TITLE
Optimized map::insert

### DIFF
--- a/brigand/sequences/map.hpp
+++ b/brigand/sequences/map.hpp
@@ -48,9 +48,6 @@ namespace detail
         template<class K, class P>
         static type_<typename P::second_type> at_impl(pair<K,P>*);
 
-        template <class P>
-        static map_impl insert_impl(pair<typename P::first_type, P>*);
-
     public:
         template<class K>
         static decltype(at_impl<K>(static_cast<Pack*>(nullptr))) at(type_<K>);
@@ -58,8 +55,8 @@ namespace detail
         template<class K>
         static type_<no_such_type_> at(K);
 
-        template <class P>
-        static decltype(insert_impl<P>(static_cast<Pack*>(nullptr))) insert(type_<P>);
+        template <class P, class = decltype(static_cast<pair<typename P::first_type, P>*>(static_cast<Pack*>(nullptr)))>
+        static map_impl insert(type_<P>);
 
         template <class P>
         static map_impl<Ts..., typename P::type> insert(P);

--- a/brigand/sequences/map.hpp
+++ b/brigand/sequences/map.hpp
@@ -38,19 +38,6 @@ namespace detail
         using type = decltype(map_type::template insert_impl<K>(find_result{}));
     };
 
-    template <class... T>
-    struct map_inserter
-    {
-        template <class K, typename U>
-        static map_impl<T...> insert_impl(U);
-
-        template <class K>
-        static map_impl<T..., K> insert_impl(no_such_type_);
-
-        template <class K>
-        static typename map_inserter_impl<K, T...>::type insert(type_<K>);
-    };
-
     template <>
     struct map_impl<>
     {
@@ -62,7 +49,7 @@ namespace detail
     };
 
     template <class... Ts>
-    struct map_impl : map_inserter<Ts...>
+    struct map_impl
     {
     private:
         struct Pack : pair<typename Ts::first_type, Ts>... {};
@@ -71,11 +58,21 @@ namespace detail
         static type_<typename P::second_type> at_impl(pair<K,P>*);
 
     public:
+        template <class K, typename U>
+        static map_impl<Ts...> insert_impl(U);
+
+        template <class K>
+        static map_impl<Ts..., K> insert_impl(no_such_type_);
+
+    public:
         template<class K>
         static decltype(at_impl<K>(static_cast<Pack*>(nullptr))) at(type_<K>);
 
         template<class K>
         static type_<no_such_type_> at(K);
+
+        template <class K>
+        static typename map_inserter_impl<K, Ts...>::type insert(type_<K>);
     };
 
     // if you have a "class already a base" error message, it means you have defined a map with the same key present more

--- a/brigand/sequences/map.hpp
+++ b/brigand/sequences/map.hpp
@@ -29,15 +29,6 @@ namespace detail
     template <class... T>
     struct map_impl;
 
-    template <class K, class... T>
-    struct map_inserter_impl
-    {
-        using index_type = typename K::first_type;
-        using map_type = map_impl<T...>;
-        using find_result = lookup<map_type, index_type>;
-        using type = decltype(map_type::template insert_impl<K>(find_result{}));
-    };
-
     template <>
     struct map_impl<>
     {
@@ -57,12 +48,11 @@ namespace detail
         template<class K, class P>
         static type_<typename P::second_type> at_impl(pair<K,P>*);
 
-    public:
         template <class K, typename U>
         static map_impl<Ts...> insert_impl(U);
 
         template <class K>
-        static map_impl<Ts..., K> insert_impl(no_such_type_);
+        static map_impl<Ts..., K> insert_impl(type_<no_such_type_>);
 
     public:
         template<class K>
@@ -71,8 +61,8 @@ namespace detail
         template<class K>
         static type_<no_such_type_> at(K);
 
-        template <class K>
-        static typename map_inserter_impl<K, Ts...>::type insert(type_<K>);
+        template <class P>
+        static decltype(insert_impl<P>(at(type_<typename P::first_type>{}))) insert(type_<P>);
     };
 
     // if you have a "class already a base" error message, it means you have defined a map with the same key present more

--- a/brigand/sequences/map.hpp
+++ b/brigand/sequences/map.hpp
@@ -48,11 +48,8 @@ namespace detail
         template<class K, class P>
         static type_<typename P::second_type> at_impl(pair<K,P>*);
 
-        template <class K, typename U>
-        static map_impl<Ts...> insert_impl(U);
-
-        template <class K>
-        static map_impl<Ts..., K> insert_impl(type_<no_such_type_>);
+        template <class P>
+        static map_impl insert_impl(pair<typename P::first_type, P>*);
 
     public:
         template<class K>
@@ -62,7 +59,10 @@ namespace detail
         static type_<no_such_type_> at(K);
 
         template <class P>
-        static decltype(insert_impl<P>(at(type_<typename P::first_type>{}))) insert(type_<P>);
+        static decltype(insert_impl<P>(static_cast<Pack*>(nullptr))) insert(type_<P>);
+
+        template <class P>
+        static map_impl<Ts..., typename P::type> insert(P);
     };
 
     // if you have a "class already a base" error message, it means you have defined a map with the same key present more


### PR DESCRIPTION
```cpp
template<int N, class L = brigand::range<int, 0, N>>
struct mk_map;

template<int N, class... T>
struct mk_map<N, brigand::list<T...>> {
  using type = brigand::map<brigand::pair<T,T>...>;
};

template<class T> using fn = decltype(mk_map<SIZE>::type::insert(brigand::type_<brigand::pair<T,int>>{}));

using list = brigand::transform<mk_map<SIZE>::type, brigand::quote<fn>>;
```

Gcc:

Size = |      100      |      200      |      300
------ | ------------- | ------------- | -------------
before | 00.19s -  49M | 00.51s - 115M | 00.98s - 266M
after  | 00.12s -  38M | 00.28s -  78M | 00.53s - 167M

Clang:

Size = |      100      |      200      |      300
------ | ------------- | ------------- | -------------
before | 00.18s -  48M | 00.43s -  75M | 00.76s - 116M
after  | 00.12s -  41M | 00.22s -  51M | 00.35s -  64M

