### PR TITLE
Fix header install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ configure_file(libbrigand.pc.in
     @ONLY
 )
 
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/brigand
     DESTINATION include
 )
 


### PR DESCRIPTION
The source directory for the header-install command needs point to brigand. Otherwise the headers will be installed into $CMAKE_INSTALL_PREFIX/include/include/brigand.