### PR TITLE
Integer math operations deduce types

### DIFF
--- a/include/brigand/functions/arithmetic/divides.hpp
+++ b/include/brigand/functions/arithmetic/divides.hpp
@@ -10,7 +10,11 @@
 
 namespace brigand
 {
-  template <typename A, typename B>
-  struct divides : brigand::integral_constant < typename A::value_type, A::value / B::value > {};
+template <typename A, typename B>
+struct divides
+    : brigand::integral_constant<typename std::decay<decltype(A::value / B::value)>::type,
+                                 A::value / B::value>
+{
+};
 }
 #endif

--- a/include/brigand/functions/arithmetic/max.hpp
+++ b/include/brigand/functions/arithmetic/max.hpp
@@ -10,10 +10,10 @@
 
 namespace brigand
 {
-  template <typename A, typename B>
-  struct max : brigand::integral_constant < typename A::value_type
-                                      , (A::value < B::value) ? B::value : A::value
-                                      >
-  {};
+template <typename A, typename B>
+struct max : brigand::integral_constant<
+                 typename std::decay<decltype((A::value < B::value) ? B::value : A::value)>::type,
+                 (A::value < B::value) ? B::value : A::value>
+{};
 }
 #endif

--- a/include/brigand/functions/arithmetic/min.hpp
+++ b/include/brigand/functions/arithmetic/min.hpp
@@ -11,8 +11,9 @@
 namespace brigand
 {
 template <typename A, typename B>
-struct min : brigand::integral_constant<typename A::value_type,
-                                        (A::value < B::value) ? A::value : B::value>
+struct min : brigand::integral_constant<
+                 typename std::decay<decltype((A::value < B::value) ? A::value : B::value)>::type,
+                 (A::value < B::value) ? A::value : B::value>
 {
 };
 }

--- a/include/brigand/functions/arithmetic/minus.hpp
+++ b/include/brigand/functions/arithmetic/minus.hpp
@@ -11,7 +11,8 @@
 namespace brigand
 {
 template <typename A, typename B>
-struct minus : brigand::integral_constant<typename A::value_type, A::value - B::value>
+struct minus : brigand::integral_constant<typename std::decay<decltype(A::value - B::value)>::type,
+                                          A::value - B::value>
 {
 };
 }

--- a/include/brigand/functions/arithmetic/modulo.hpp
+++ b/include/brigand/functions/arithmetic/modulo.hpp
@@ -11,7 +11,8 @@
 namespace brigand
 {
 template <typename A, typename B>
-struct modulo : brigand::integral_constant<typename A::value_type, A::value % B::value>
+struct modulo : brigand::integral_constant<typename std::decay<decltype(A::value % B::value)>::type,
+                                           A::value % B::value>
 {
 };
 }

--- a/include/brigand/functions/arithmetic/plus.hpp
+++ b/include/brigand/functions/arithmetic/plus.hpp
@@ -11,7 +11,8 @@
 namespace brigand
 {
 template <typename A, typename B>
-struct plus : brigand::integral_constant<typename A::value_type, A::value + B::value>
+struct plus : brigand::integral_constant<typename std::decay<decltype(A::value + B::value)>::type,
+                                         A::value + B::value>
 {
 };
 }

--- a/include/brigand/functions/arithmetic/times.hpp
+++ b/include/brigand/functions/arithmetic/times.hpp
@@ -11,7 +11,8 @@
 namespace brigand
 {
 template <typename A, typename B>
-struct times : brigand::integral_constant<typename A::value_type, A::value * B::value>
+struct times : brigand::integral_constant<typename std::decay<decltype(A::value * B::value)>::type,
+                                          A::value * B::value>
 {
 };
 }

--- a/test/integral_test.cpp
+++ b/test/integral_test.cpp
@@ -22,3 +22,60 @@ static_assert(brigand::prev<brigand::prev<value_int_three>>::value == 1, "invali
 static_assert(brigand::prev<brigand::next<value_int_one>>::value == 1, "invalid prev next result");
 static_assert(brigand::negate<value_int_three>::value == -3, "invalid negate result");
 static_assert(brigand::complement<value_byte_zero>::value == 255, "invalid complement result");
+
+static_assert(std::is_same<typename brigand::min<brigand::integral_constant<short, 10>,
+                                                 brigand::integral_constant<long, 3>>::type,
+                           brigand::integral_constant<long, 3>>::value,
+              "failed min with cast");
+static_assert(std::is_same<typename brigand::min<brigand::integral_constant<long, 10>,
+                                                 brigand::integral_constant<short, 3>>::type,
+                           brigand::integral_constant<long, 3>>::value,
+              "failed min with cast");
+static_assert(std::is_same<typename brigand::max<brigand::integral_constant<short, 10>,
+                                                 brigand::integral_constant<long, 3>>::type,
+                           brigand::integral_constant<long, 10>>::value,
+              "failed max with cast");
+static_assert(std::is_same<typename brigand::max<brigand::integral_constant<long, 10>,
+                                                 brigand::integral_constant<short, 3>>::type,
+                           brigand::integral_constant<long, 10>>::value,
+              "failed max with cast");
+static_assert(std::is_same<typename brigand::plus<brigand::integral_constant<short, 1>,
+                                                  brigand::integral_constant<long, 2>>::type,
+                           brigand::integral_constant<long, 3>>::value,
+              "failed addition with cast");
+static_assert(std::is_same<typename brigand::plus<brigand::integral_constant<long, 1>,
+                                                  brigand::integral_constant<short, 2>>::type,
+                           brigand::integral_constant<long, 3>>::value,
+              "failed addition with cast");
+static_assert(std::is_same<typename brigand::minus<brigand::integral_constant<short, 1>,
+                                                   brigand::integral_constant<long, 2>>::type,
+                           brigand::integral_constant<long, -1>>::value,
+              "failed subtraction with cast");
+static_assert(std::is_same<typename brigand::minus<brigand::integral_constant<long, 1>,
+                                                   brigand::integral_constant<short, 2>>::type,
+                           brigand::integral_constant<long, -1>>::value,
+              "failed subtraction with cast");
+static_assert(std::is_same<typename brigand::times<brigand::integral_constant<short, 1>,
+                                                   brigand::integral_constant<long, 2>>::type,
+                           brigand::integral_constant<long, 2>>::value,
+              "failed times with cast");
+static_assert(std::is_same<typename brigand::times<brigand::integral_constant<long, 1>,
+                                                   brigand::integral_constant<short, 2>>::type,
+                           brigand::integral_constant<long, 2>>::value,
+              "failed times with cast");
+static_assert(std::is_same<typename brigand::divides<brigand::integral_constant<short, 4>,
+                                                     brigand::integral_constant<long, 2>>::type,
+                           brigand::integral_constant<long, 2>>::value,
+              "failed divides with cast");
+static_assert(std::is_same<typename brigand::divides<brigand::integral_constant<long, 4>,
+                                                     brigand::integral_constant<short, 2>>::type,
+                           brigand::integral_constant<long, 2>>::value,
+              "failed divides with cast");
+static_assert(std::is_same<typename brigand::modulo<brigand::integral_constant<short, 10>,
+                                                    brigand::integral_constant<long, 3>>::type,
+                           brigand::integral_constant<long, 1>>::value,
+              "failed modulo with cast");
+static_assert(std::is_same<typename brigand::modulo<brigand::integral_constant<long, 10>,
+                                                    brigand::integral_constant<short, 3>>::type,
+                           brigand::integral_constant<long, 1>>::value,
+              "failed modulo with cast");


### PR DESCRIPTION
Adding an int and a long will deduce to a long instead of an int.