### PR TITLE
Added variadic and_/or_ and tests for 0-arg, 1-arg, and 3-arg cases

### DIFF
--- a/include/brigand/functions/logical/and.hpp
+++ b/include/brigand/functions/logical/and.hpp
@@ -6,11 +6,46 @@
 */
 #ifndef BOOST_BRIGAND_FUNCTIONS_LOGICAL_AND_HPP
 #define BOOST_BRIGAND_FUNCTIONS_LOGICAL_AND_HPP
-#include <brigand/types/integral_constant.hpp>
+#include <brigand/types/bool.hpp>
 
 namespace brigand
 {
-  template <typename A, typename B>
-  struct and_ : brigand::integral_constant <typename A::value_type, A::value && B::value > {};
+namespace detail
+{
+    template <unsigned N>
+    struct and_impl;
+
+    template <>
+    struct and_impl<0>
+    {
+        template <typename T0=bool_<true>, typename T1 = bool_<true>, typename T2 = bool_<true>,
+                  typename T3=bool_<true>, typename T4 = bool_<true>, typename T5 = bool_<true>,
+                  typename T6=bool_<true>, typename T7 = bool_<true>, typename T8 = bool_<true>>
+        using f = bool_<T0::value && T1::value && T2::value && T3::value && T4::value &&
+                        T5::value && T6::value && T7::value && T8::value>;
+    };
+
+    template<>
+    struct and_impl<1>
+    {
+        template <typename T0=bool_<true>, typename T1 = bool_<true>, typename T2 = bool_<true>,
+                  typename T3=bool_<true>, typename T4 = bool_<true>, typename T5 = bool_<true>,
+                  typename T6=bool_<true>, typename T7 = bool_<true>, typename T8 = bool_<true>,
+                  typename T9=bool_<true>, typename T10 = bool_<true>, typename T11 = bool_<true>,
+                  typename T12=bool_<true>, typename T13 = bool_<true>, typename T14 = bool_<true>,
+                  typename T15=bool_<true>, typename T16 = bool_<true>, typename T17 = bool_<true>,
+                  typename T18=bool_<true>, typename T19 = bool_<true>, typename... Ts>
+        using f = bool_<T0::value && T1::value && T2::value && T3::value && T4::value &&
+                        T5::value && T6::value && T7::value && T8::value && T9::value &&
+                        T10::value && T11::value && T12::value && T13::value && T14::value &&
+                        T15::value && T16::value && T17::value && T18::value && T19::value &&
+                        and_impl<bool(sizeof...(Ts) / 9)>::template f<Ts...>::value>;
+    };
+}
+
+template<typename...Ts>
+struct and_: detail::and_impl<bool(sizeof...(Ts) / 9)>::template f<Ts...>
+{};
+
 }
 #endif

--- a/include/brigand/functions/logical/or.hpp
+++ b/include/brigand/functions/logical/or.hpp
@@ -6,11 +6,46 @@
 */
 #ifndef BOOST_BRIGAND_FUNCTIONS_LOGICAL_OR_HPP
 #define BOOST_BRIGAND_FUNCTIONS_LOGICAL_OR_HPP
-#include <brigand/types/integral_constant.hpp>
+#include <brigand/types/bool.hpp>
 
 namespace brigand
 {
-  template <typename A, typename B>
-  struct or_ : brigand::integral_constant < typename A::value_type, A::value || B::value > {};
+namespace detail
+{
+    template <unsigned N>
+    struct or_impl;
+
+    template <>
+    struct or_impl<0>
+    {
+        template <typename T0=bool_<false>, typename T1 = bool_<false>, typename T2 = bool_<false>,
+                  typename T3=bool_<false>, typename T4 = bool_<false>, typename T5 = bool_<false>,
+                  typename T6=bool_<false>, typename T7 = bool_<false>, typename T8 = bool_<false>>
+        using f = bool_<T0::value || T1::value || T2::value || T3::value || T4::value ||
+                        T5::value || T6::value || T7::value || T8::value>;
+    };
+
+    template<>
+    struct or_impl<1>
+    {
+        template <typename T0=bool_<false>, typename T1 = bool_<false>, typename T2 = bool_<false>,
+                  typename T3=bool_<false>, typename T4 = bool_<false>, typename T5 = bool_<false>,
+                  typename T6=bool_<false>, typename T7 = bool_<false>, typename T8 = bool_<false>,
+                  typename T9=bool_<false>, typename T10 = bool_<false>, typename T11 = bool_<false>,
+                  typename T12=bool_<false>, typename T13 = bool_<false>, typename T14 = bool_<false>,
+                  typename T15=bool_<false>, typename T16 = bool_<false>, typename T17 = bool_<false>,
+                  typename T18=bool_<false>, typename T19 = bool_<false>, typename... Ts>
+        using f = bool_<T0::value || T1::value || T2::value || T3::value || T4::value ||
+                        T5::value || T6::value || T7::value || T8::value || T9::value ||
+                        T10::value || T11::value || T12::value || T13::value || T14::value ||
+                        T15::value || T16::value || T17::value || T18::value || T19::value ||
+                        or_impl<bool(sizeof...(Ts) / 9)>::template f<Ts...>::value>;
+    };
+}
+
+template<typename...Ts>
+struct or_: detail::or_impl<bool(sizeof...(Ts) / 9)>::template f<Ts...>
+{};
+
 }
 #endif

--- a/test/logical_test.cpp
+++ b/test/logical_test.cpp
@@ -7,6 +7,12 @@ static_assert(brigand::not_<brigand::false_type>::value == true, "invalid not re
 static_assert(brigand::not_<brigand::not_<brigand::true_type>>::value == true,
               "invalid not result");
 
+static_assert(brigand::and_<>::value == true,
+              "invalid not result");
+static_assert(brigand::and_<brigand::false_type>::value == false,
+              "invalid not result");
+static_assert(brigand::and_<brigand::true_type>::value == true,
+              "invalid not result");
 static_assert(brigand::and_<brigand::false_type, brigand::false_type>::value == false,
               "invalid and result");
 static_assert(brigand::and_<brigand::false_type, brigand::true_type>::value == false,
@@ -15,10 +21,73 @@ static_assert(brigand::and_<brigand::true_type, brigand::false_type>::value == f
               "invalid and result");
 static_assert(brigand::and_<brigand::true_type, brigand::true_type>::value == true,
               "invalid and result");
+static_assert(brigand::and_<brigand::false_type, brigand::false_type, brigand::false_type>::value == false,
+              "invalid not result");
+static_assert(brigand::and_<brigand::true_type, brigand::false_type, brigand::false_type>::value == false,
+              "invalid not result");
+static_assert(brigand::and_<brigand::true_type, brigand::true_type, brigand::false_type>::value == false,
+              "invalid not result");
+static_assert(brigand::and_<brigand::true_type, brigand::true_type, brigand::true_type>::value == true,
+              "invalid not result");
 
 static_assert(brigand::and_<brigand::not_<brigand::true_type>, brigand::false_type>::value == false,
               "invalid and/not result");
 
+static_assert(brigand::and_<brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::false_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type>::value == false,
+              "invalid or result");
+
+static_assert(brigand::and_<brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type,
+              brigand::true_type, brigand::true_type>::value == true,
+              "invalid or result");
+
+
+static_assert(brigand::or_<>::value == false,
+              "invalid not result");
+static_assert(brigand::or_<brigand::false_type>::value == false,
+              "invalid not result");
+static_assert(brigand::or_<brigand::true_type>::value == true,
+              "invalid not result");
 static_assert(brigand::or_<brigand::false_type, brigand::false_type>::value == false,
               "invalid or result");
 static_assert(brigand::or_<brigand::false_type, brigand::true_type>::value == true,
@@ -26,6 +95,62 @@ static_assert(brigand::or_<brigand::false_type, brigand::true_type>::value == tr
 static_assert(brigand::or_<brigand::true_type, brigand::false_type>::value == true,
               "invalid or result");
 static_assert(brigand::or_<brigand::true_type, brigand::true_type>::value == true,
+              "invalid or result");
+static_assert(brigand::or_<brigand::false_type, brigand::false_type, brigand::false_type>::value == false,
+              "invalid not result");
+static_assert(brigand::or_<brigand::true_type, brigand::false_type, brigand::false_type>::value == true,
+              "invalid not result");
+static_assert(brigand::or_<brigand::true_type, brigand::true_type, brigand::false_type>::value == true,
+              "invalid not result");
+static_assert(brigand::or_<brigand::true_type, brigand::true_type, brigand::true_type>::value == true,
+              "invalid not result");
+
+static_assert(brigand::or_<brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type>::value == false,
+              "invalid or result");
+
+static_assert(brigand::or_<brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::true_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type,
+              brigand::false_type, brigand::false_type>::value == true,
               "invalid or result");
 
 static_assert(brigand::xor_<brigand::false_type, brigand::false_type>::value == false,


### PR DESCRIPTION
I've added a variadic overload for the `and_` and `or_` logical operators, which should scale linearly with the size of the parameter pack.

The general idea is quite simple:

1. Declare a variadic class template.
2. Specialize for the 0-case (true for `and_` and false for `or_`).
3. Use recursion to implement the operator (for `and_`, using `T::value && and_<Ts...>::value`.).

I've implemented test cases for the 0-arg, 1-arg, and 3-arg cases, demonstrating that they are logically sound. Since the implementation is recursive, demonstrating the 0 and 1-arg cases would prove the N-arg case.