### PR TITLE
Add documentation for brigand::flatten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,3 +314,5 @@ install(FILES ${CMAKE_BINARY_DIR}/libbrigand.pc
 
 include(SetupDoxygen)
 include(SetupStandardese)
+
+add_subdirectory(examples)

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -84,7 +84,7 @@ EXCLUDE_PATTERNS = */CMake/* */README.md
 
 EXCLUDE_SYMBOLS = *detail* std*
 
-EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@/test/*
+EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@/examples/
 
 EXAMPLE_PATTERNS       =
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(brigand_examples
+  flatten.cpp
+  )

--- a/examples/flatten.cpp
+++ b/examples/flatten.cpp
@@ -1,0 +1,20 @@
+/*!
+@file Example of using brigand::flatten
+
+@copyright Edouard Alligand and Joel Falcou 2015-2017
+(See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+
+/// [flatten_simple_example]
+#include <brigand/brigand.hpp>
+
+using list1 = brigand::list<double, int, char>;
+using list2 = brigand::list<long, unsigned char>;
+using flat_list = brigand::flatten<
+    brigand::list<list1, list2, short, brigand::list<brigand::list<unsigned long>>>>;
+
+static_assert(
+    std::is_same<flat_list,
+                 brigand::list<double, int, char, long, unsigned char, short, unsigned long>>::value,
+    "failed to compile brigand::flatten example");
+/// [flatten_simple_example]

--- a/include/brigand/algorithms/flatten.hpp
+++ b/include/brigand/algorithms/flatten.hpp
@@ -47,6 +47,18 @@ namespace lazy
     using flatten = typename detail::flatten_impl<Sequence>;
 }
 
+/*!
+ * \ingroup Algorithms
+ * \ingroup List
+ * \brief Merge the contents of several lists into one list
+ *
+ * Given a list of lists and types, returns a new list with the contents of the lists and the types.
+ *
+ * \example
+ * Below is an example of how to use brigand::flatten. The `static_assert` is used to show the
+ * returned list from flatten
+ * \snippet flatten.cpp flatten_simple_example
+ */
 template <typename Sequence>
 using flatten = typename lazy::flatten<Sequence>::type;
 


### PR DESCRIPTION
I will add a configuration to travis to build and push the documentation to gh-pages in a separate PR. For now, I want to start getting documentation in so users can look at it.