### PR TITLE
Build documentation on travis-ci and push to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-5']
-      env: TOOLSET=g++-5
+          packages: ['g++-5', 'graphviz', 'doxygen']
+      env: TOOLSET=g++-5 GENERATE_DOCUMENTATION=true
 
     - os: linux
       compiler: clang
@@ -65,3 +65,19 @@ before_script:
 script:
   - make VERBOSE=1
   - ./brigand_test
+
+after_success:
+  - if [ "${GENERATE_DOCUMENTATION}" == "true" ]; then
+      cd $TRAVIS_BUILD_DIR/build;
+      make doxygen VERBOSE=1;
+      cd $TRAVIS_BUILD_DIR;
+    fi
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: build/doc/html/
+  github_token: $GITHUB_API_TOKEN
+  on:
+    branch: master
+    condition: $GENERATE_DOCUMENTATION = true

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -80,7 +80,7 @@ EXCLUDE                =
 
 EXCLUDE_SYMLINKS       = NO
 
-EXCLUDE_PATTERNS = */CMake/* */README.md
+EXCLUDE_PATTERNS = */CMake/* */README.md boost*
 
 EXCLUDE_SYMBOLS = *detail* std*
 


### PR DESCRIPTION
- This currently uses Doxygen, the main reason being I'm most familiar with it and want to get content up quickly. Once things are working I'll look at switching to standardese.
- [ ] Someone who has write access to the repo needs to add a Personal Access Token (GitHub Settings -> Developer Settings -> Personal Access Tokens) as a secret variable named `GITHUB_API_TOKEN` to TravisCI -> Settings for this repo. What will happen is that all builds on master will build and push documentation to gh-pages and the documentation will then be available at: https://edouarda.github.io/brigand

- I have a copy of the current documentation on my fork's gh-pages branch: http://nilsdeppe.com/brigand/