### PR TITLE
Fix lazy::replace when used in a metalambda

### DIFF
--- a/include/brigand/algorithms/replace.hpp
+++ b/include/brigand/algorithms/replace.hpp
@@ -71,7 +71,7 @@ namespace lazy
     //#endif
 
     template <typename Sequence, typename OldType, typename NewType>
-    using replace = replace_if<Sequence, std::is_same<_1, pin<OldType>>, NewType>;
+    struct replace : replace_if<Sequence, std::is_same<_1, pin<OldType>>, NewType> {};
 }
 
 template <typename Sequence, typename Predicate, typename NewType>

--- a/include/standalone/brigand.hpp
+++ b/include/standalone/brigand.hpp
@@ -1772,7 +1772,7 @@ namespace lazy
         using type = S<typename detail::replacer<Ts, Predicate, NewType>::type...>;
     };
     template <typename Sequence, typename OldType, typename NewType>
-    using replace = replace_if<Sequence, std::is_same<_1, pin<OldType>>, NewType>;
+    struct replace : replace_if<Sequence, std::is_same<_1, pin<OldType>>, NewType> {};
 }
 template <typename Sequence, typename Predicate, typename NewType>
 using replace_if = typename ::brigand::lazy::replace_if<Sequence, Predicate, NewType>::type;

--- a/test/replace.cpp
+++ b/test/replace.cpp
@@ -53,3 +53,6 @@ namespace custom
   brigand::replace_if<custom_list<int, float, char, double, int, unsigned int>, pred_fp, long>
     replace_test6 = custom_list<int, long, char, long, int, unsigned int>{};
 }
+
+brigand::apply<brigand::lazy::replace<brigand::pin<brigand::list<int>>, int, float>>
+replace_lazy_test1 = brigand::list<float>{};


### PR DESCRIPTION
The metalambda in the implementation needed to be hidden from the
outer parser.