### PR TITLE
Prevent insertion of duplicate keys in maps

### DIFF
--- a/include/brigand/sequences/map.hpp
+++ b/include/brigand/sequences/map.hpp
@@ -92,8 +92,7 @@ namespace detail
         template <class K>
         static typename erase_return_t<K, Ts...>::type erase(type_<K>);
 
-        template <class P, class = decltype(static_cast<pair<typename P::first_type, P> *>(
-                               static_cast<Pack *>(nullptr)))>
+        template <class P, class = decltype(at_impl<typename P::first_type>(static_cast<Pack *>(nullptr)))>
         static map_impl insert(type_<P>);
 
         template <class P>

--- a/include/standalone/brigand.hpp
+++ b/include/standalone/brigand.hpp
@@ -216,8 +216,7 @@ namespace detail
         };
         template <class K>
         static typename erase_return_t<K, Ts...>::type erase(type_<K>);
-        template <class P, class = decltype(static_cast<pair<typename P::first_type, P> *>(
-                               static_cast<Pack *>(nullptr)))>
+        template <class P, class = decltype(at_impl<typename P::first_type>(static_cast<Pack *>(nullptr)))>
         static map_impl insert(type_<P>);
         template <class P>
         static map_impl<Ts..., typename P::type> insert(P);

--- a/test/map_test.cpp
+++ b/test/map_test.cpp
@@ -125,3 +125,6 @@ static_assert(std::is_same<brigand::insert<big_map, pair_seven>, big_map>::value
 static_assert(std::is_same<brigand::insert<big_map, pair_eight>, big_map>::value, "insertion failed");
 static_assert(std::is_same<brigand::insert<big_map, pair_nine>, big_map>::value, "insertion failed");
 static_assert(std::is_same<brigand::insert<big_map, pair_ten>, big_map>::value, "insertion failed");
+
+// Test inserting a duplicate key with a different value
+static_assert(std::is_same<brigand::insert<big_map, brigand::pair<type_one, double>>, big_map>::value, "insertion failed");


### PR DESCRIPTION
Previously the values were improperly used in the uniqueness check.