### PR TITLE
Add standard CMake `BUILD_TESTING` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ set(brigand_VERSION 1.3.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake")
 
-enable_testing()
-
 if((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -pedantic -Wold-style-cast")
@@ -228,76 +226,10 @@ set(BRIGAND_HEADERS ${BRIGAND_GROUP}
     ${SEQUENCES_GROUP}
     ${TYPES_GROUP})
 
-set(test_files
-    ${PROJECT_SOURCE_DIR}/test/always.cpp
-    ${PROJECT_SOURCE_DIR}/test/apply.cpp
-    ${PROJECT_SOURCE_DIR}/test/args.cpp
-    ${PROJECT_SOURCE_DIR}/test/bind.cpp
-    ${PROJECT_SOURCE_DIR}/test/bitwise_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/comparison_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/count_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/config_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/eval_if_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/erase_c_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/find.cpp
-    ${PROJECT_SOURCE_DIR}/test/flatten.cpp
-    ${PROJECT_SOURCE_DIR}/test/fold.cpp
-    ${PROJECT_SOURCE_DIR}/test/for_each.cpp
-    ${PROJECT_SOURCE_DIR}/test/identity.cpp
-    ${PROJECT_SOURCE_DIR}/test/if_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/index_of.cpp
-    ${PROJECT_SOURCE_DIR}/test/include_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/inherit.cpp
-    ${PROJECT_SOURCE_DIR}/test/inherit_linearly.cpp
-    ${PROJECT_SOURCE_DIR}/test/integer.cpp
-    ${PROJECT_SOURCE_DIR}/test/integral_list_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/integral_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/is_set_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/keys_as_sequence.cpp
-    ${PROJECT_SOURCE_DIR}/test/list_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/logical_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/main.cpp
-    ${PROJECT_SOURCE_DIR}/test/make_sequence_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/map_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/merge_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/pair_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/partition_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/predicate_reduction_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/range_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/real.cpp
-    ${PROJECT_SOURCE_DIR}/test/remove_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/repeat_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/replace.cpp
-    ${PROJECT_SOURCE_DIR}/test/reverse_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/select.cpp
-    ${PROJECT_SOURCE_DIR}/test/set_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/sizeof.cpp
-    ${PROJECT_SOURCE_DIR}/test/sort_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/split.cpp
-    ${PROJECT_SOURCE_DIR}/test/split_at.cpp
-    ${PROJECT_SOURCE_DIR}/test/transform.cpp
-    ${PROJECT_SOURCE_DIR}/test/tuple_test.cpp
-    ${PROJECT_SOURCE_DIR}/test/values_as_sequence.cpp
-)
-
-if(Boost_FOUND)
-    set(test_files
-        ${test_files}
-        test/variant_test.cpp
-        test/fusion_test.cpp)
+include(CTest)
+if(BUILD_TESTING)
+    add_subdirectory(test)
 endif()
-
-source_group(tests FILES ${test_files})
-
-add_executable(brigand_test ${test_files})
-
-IF(${CMAKE_MAJOR_VERSION} GREATER 2)
-    add_library(brigand INTERFACE)
-    add_custom_target(brigand_headers SOURCES ${BRIGAND_HEADERS})
-    target_link_libraries(brigand_test brigand)
-ENDIF()
-
-add_test(NAME brigand_test COMMAND brigand_test)
 
 configure_file(libbrigand.pc.in
     libbrigand.pc
@@ -315,4 +247,7 @@ install(FILES ${CMAKE_BINARY_DIR}/libbrigand.pc
 include(SetupDoxygen)
 include(SetupStandardese)
 
-add_subdirectory(examples)
+option(BUILD_EXAMPLES "Build examples" ${BUILD_TESTING})
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,70 @@
+set(test_files
+    always.cpp
+    apply.cpp
+    args.cpp
+    bind.cpp
+    bitwise_test.cpp
+    comparison_test.cpp
+    count_test.cpp
+    config_test.cpp
+    eval_if_test.cpp
+    erase_c_test.cpp
+    find.cpp
+    flatten.cpp
+    fold.cpp
+    for_each.cpp
+    identity.cpp
+    if_test.cpp
+    index_of.cpp
+    include_test.cpp
+    inherit.cpp
+    inherit_linearly.cpp
+    integer.cpp
+    integral_list_test.cpp
+    integral_test.cpp
+    is_set_test.cpp
+    keys_as_sequence.cpp
+    list_test.cpp
+    logical_test.cpp
+    main.cpp
+    make_sequence_test.cpp
+    map_test.cpp
+    merge_test.cpp
+    pair_test.cpp
+    partition_test.cpp
+    predicate_reduction_test.cpp
+    range_test.cpp
+    real.cpp
+    remove_test.cpp
+    repeat_test.cpp
+    replace.cpp
+    reverse_test.cpp
+    select.cpp
+    set_test.cpp
+    sizeof.cpp
+    sort_test.cpp
+    split.cpp
+    split_at.cpp
+    transform.cpp
+    tuple_test.cpp
+    values_as_sequence.cpp
+)
+
+if(Boost_FOUND)
+    set(test_files
+        ${test_files}
+        variant_test.cpp
+        fusion_test.cpp)
+endif()
+
+source_group(tests FILES ${test_files})
+
+add_executable(brigand_test ${test_files})
+
+IF(${CMAKE_MAJOR_VERSION} GREATER 2)
+    add_library(brigand INTERFACE)
+    add_custom_target(brigand_headers SOURCES ${BRIGAND_HEADERS})
+    target_link_libraries(brigand_test brigand)
+ENDIF()
+
+add_test(NAME brigand_test COMMAND brigand_test)


### PR DESCRIPTION
Move CMake code that sets up tests to `test/`. Also add `BUILD_EXAMPLES` option.

Now a configuration like this:

```
cmake -D BUILD_TESTING=OFF ..
```

doesn't compile anything on `make all`, as expected for a header-only library. This simplifies installation with [Spack](https://github.com/spack/spack).

See the [CMake docs on Test](https://cmake.org/cmake/help/latest/module/CTest.html) for the standard way to set up tests.