### PR TITLE
Fix all/none on C++11 libc++

### DIFF
--- a/include/brigand/algorithms/all.hpp
+++ b/include/brigand/algorithms/all.hpp
@@ -15,7 +15,9 @@
 
 namespace brigand
 {
-#if defined(BRIGAND_COMP_MSVC_2013) || defined(BRIGAND_COMP_CUDA) || defined(BRIGAND_COMP_INTEL)
+// defined(_LIBCPP_VERSION) && __cplusplus < 201402L
+// - std::initializer_list is not a literal type in libc++ until C++14
+#if defined(BRIGAND_COMP_MSVC_2013) || defined(BRIGAND_COMP_CUDA) || defined(BRIGAND_COMP_INTEL) || (defined(_LIBCPP_VERSION) && __cplusplus < 201402L)
 namespace detail
 {
     template <class P, class T>

--- a/include/brigand/algorithms/count.hpp
+++ b/include/brigand/algorithms/count.hpp
@@ -108,7 +108,7 @@ namespace lazy
     struct count_if<S<Ts...>, bind<F, _1>>
     {
 #if __cplusplus >= 201402L
-        static constexpr std::array<bool, sizeof...(Ts)> s_v{{F<Ts>::type::value...}};
+        static constexpr std::array<bool, sizeof...(Ts)> s_v{{F<Ts>::value...}};
         using type = brigand::size_t<::brigand::detail::count_bools(s_v)>;
 #else
         static constexpr bool s_v[] = {F<Ts>::value...};

--- a/include/brigand/algorithms/none.hpp
+++ b/include/brigand/algorithms/none.hpp
@@ -14,7 +14,9 @@
 
 namespace brigand
 {
-#if defined(BRIGAND_COMP_MSVC_2013) || defined(BRIGAND_COMP_CUDA) || defined(BRIGAND_COMP_INTEL)
+// defined(_LIBCPP_VERSION) && __cplusplus < 201402L
+// - std::initializer_list is not a literal type in libc++ until C++14
+#if defined(BRIGAND_COMP_MSVC_2013) || defined(BRIGAND_COMP_CUDA) || defined(BRIGAND_COMP_INTEL) || (defined(_LIBCPP_VERSION) && __cplusplus < 201402L)
 namespace detail
 {
     template <typename Sequence, typename Pred>

--- a/include/standalone/brigand.hpp
+++ b/include/standalone/brigand.hpp
@@ -712,7 +712,7 @@ namespace lazy
     struct count_if<S<Ts...>, bind<F, _1>>
     {
 #if __cplusplus >= 201402L
-        static constexpr std::array<bool, sizeof...(Ts)> s_v{{F<Ts>::type::value...}};
+        static constexpr std::array<bool, sizeof...(Ts)> s_v{{F<Ts>::value...}};
         using type = brigand::size_t<::brigand::detail::count_bools(s_v)>;
 #else
         static constexpr bool s_v[] = {F<Ts>::value...};

--- a/include/standalone/brigand.hpp
+++ b/include/standalone/brigand.hpp
@@ -955,7 +955,7 @@ namespace detail
 #include <type_traits>
 namespace brigand
 {
-#if defined(BRIGAND_COMP_MSVC_2013) || defined(BRIGAND_COMP_CUDA) || defined(BRIGAND_COMP_INTEL)
+#if defined(BRIGAND_COMP_MSVC_2013) || defined(BRIGAND_COMP_CUDA) || defined(BRIGAND_COMP_INTEL) || (defined(_LIBCPP_VERSION) && __cplusplus < 201402L)
 namespace detail
 {
     template <class P, class T>
@@ -1022,7 +1022,7 @@ using all = typename detail::all_impl<Sequence, Predicate>::type;
 }
 namespace brigand
 {
-#if defined(BRIGAND_COMP_MSVC_2013) || defined(BRIGAND_COMP_CUDA) || defined(BRIGAND_COMP_INTEL)
+#if defined(BRIGAND_COMP_MSVC_2013) || defined(BRIGAND_COMP_CUDA) || defined(BRIGAND_COMP_INTEL) || (defined(_LIBCPP_VERSION) && __cplusplus < 201402L)
 namespace detail
 {
     template <typename Sequence, typename Pred>


### PR DESCRIPTION
Just falls back to the existing backup implementation.  I couldn't come up with a way to modify the main implementation to work.

Also fixes a minor bug in count noticed during testing in #274.

@nilsleiffischer Can you verify that this fixes your troubles?